### PR TITLE
Cita 105 signature unify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,8 +356,10 @@ dependencies = [
 name = "cita-ed25519"
 version = "0.6.0"
 dependencies = [
+ "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.14 (git+https://github.com/cryptape/sodiumoxide.git)",
  "util 0.6.0",
 ]
@@ -366,9 +368,11 @@ dependencies = [
 name = "cita-secp256k1"
 version = "0.6.0"
 dependencies = [
+ "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.6 (git+https://github.com/ethcore/rust-secp256k1)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rlp 0.2.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -482,7 +486,6 @@ dependencies = [
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "engine 0.6.0",
  "engine_json 0.6.0",
- "eth-secp256k1 0.5.6 (git+https://github.com/ethcore/rust-secp256k1)",
  "libproto 0.6.0",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ name = "chain_performance"
 version = "0.1.0"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "cita_log 0.1.0",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "common-types 0.1.0",
@@ -350,6 +350,15 @@ dependencies = [
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.6.0",
  "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cita-crypto"
+version = "0.1.0"
+dependencies = [
+ "cita-ed25519 0.6.0",
+ "cita-secp256k1 0.6.0",
+ "util 0.6.0",
 ]
 
 [[package]]
@@ -440,7 +449,7 @@ name = "common-types"
 version = "0.1.0"
 dependencies = [
  "bloomable 0.1.0",
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "libproto 0.6.0",
  "rlp 0.2.0",
  "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -452,7 +461,7 @@ name = "consensus_poa"
 version = "0.6.0"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "cita_log 0.1.0",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuprofiler 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -478,7 +487,7 @@ version = "0.1.0"
 dependencies = [
  "amqp 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "cita_log 0.1.0",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "core 0.1.0",
@@ -521,6 +530,7 @@ dependencies = [
  "bloomchain 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bn 0.4.4 (git+https://github.com/paritytech/bn)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cita-crypto 0.1.0",
  "cita-ed25519 0.6.0",
  "cita-secp256k1 0.6.0",
  "common-types 0.1.0",
@@ -648,7 +658,7 @@ name = "engine"
 version = "0.6.0"
 dependencies = [
  "amqp 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "engine_json 0.6.0",
  "libproto 0.6.0",
  "proof 0.6.0",
@@ -661,7 +671,7 @@ dependencies = [
 name = "engine_json"
 version = "0.6.0"
 dependencies = [
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -979,7 +989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libproto"
 version = "0.6.0"
 dependencies = [
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "protobuf 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.2.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1405,7 +1415,7 @@ name = "proof"
 version = "0.6.0"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "libproto 0.6.0",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2007,7 +2017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "trans_evm"
 version = "0.1.0"
 dependencies = [
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "cita_log 0.1.0",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2034,7 +2044,7 @@ dependencies = [
 name = "tx_pool"
 version = "0.6.0"
 dependencies = [
- "cita-ed25519 0.6.0",
+ "cita-crypto 0.1.0",
  "libproto 0.6.0",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "util 0.6.0",

--- a/chain/core/Cargo.toml
+++ b/chain/core/Cargo.toml
@@ -37,6 +37,7 @@ transient-hashmap = "0.4.0"
 ethcore-io = { path = "../../share_libs/io" }
 cita-ed25519 = { path = "../../share_libs/ed25519" }
 cita-secp256k1 = { path = "../../share_libs/secp256k1" }
+cita-crypto = { path = "../../share_libs/crypto" }
 
 protobuf = { version = "^1.0.0"}
 threadpool = "1.3.2"

--- a/chain/core/src/builtin.rs
+++ b/chain/core/src/builtin.rs
@@ -15,13 +15,13 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 #![allow(dead_code)]
-use cita_ed25519::{Signature as ED_Signature, recover as ed_recover};
+use cita_ed25519::{Signature as ED_Signature, recover as ed_recover, Message as ED_Message};
 use cita_secp256k1::{Signature, recover as ec_recover};
 use crypto::digest::Digest;
 use crypto::ripemd160::Ripemd160 as Ripemd160Digest;
 use crypto::sha2::Sha256 as Sha256Digest;
 use std::cmp::min;
-use util::{U256, H256, BytesRef, Hashable, H768};
+use util::{U256, H256, BytesRef, Hashable};
 // use ethjson;
 
 /// Native implementation of a built-in contract.
@@ -183,12 +183,10 @@ impl Impl for EdRecover {
         let mut input = [0; 128];
         input[..len].copy_from_slice(&i[..len]);
 
-        let hash = H256::from_slice(&input[0..32]);
-        let sig = H768::from_slice(&input[32..128]);
+        let hash = ED_Message::from_slice(&input[0..32]);
+        let sig = ED_Signature::from(&input[32..128]);
 
-
-        let s = ED_Signature::from(sig);
-        if let Ok(p) = ed_recover(&s, &hash.into()) {
+        if let Ok(p) = ed_recover(&sig, &hash.into()) {
             let r = p.crypt_hash();
             output.write(0, &[0; 12]);
             output.write(12, &r[12..r.len()]);

--- a/chain/core/src/lib.rs
+++ b/chain/core/src/lib.rs
@@ -52,6 +52,8 @@ extern crate jsonrpc_types;
 extern crate cita_secp256k1;
 #[cfg(test)]
 extern crate test;
+#[cfg(test)]
+extern crate cita_crypto;
 
 pub mod state;
 pub mod account_db;

--- a/chain/core/src/libchain/chain.rs
+++ b/chain/core/src/libchain/chain.rs
@@ -941,12 +941,12 @@ impl Chain {
 #[cfg(test)]
 mod tests {
     #![allow(unused_must_use, deprecated, unused_extern_crates)]
-    extern crate cita_ed25519;
+    extern crate cita_crypto;
     extern crate env_logger;
     extern crate mktemp;
     use self::Chain;
     use super::*;
-    use cita_ed25519::KeyPair;
+    use cita_crypto::{KeyPair, PrivKey};
     use db;
     use libchain::block::{Block, BlockBody};
     use libchain::genesis::Spec;
@@ -958,6 +958,7 @@ mod tests {
     use test::{Bencher, black_box};
     use types::transaction::SignedTransaction;
     use util::{U256, H256, Address};
+    use util::crypto::CreateKey;
     use util::kvdb::{Database, DatabaseConfig};
     //use util::hashable::HASH_NAME;
 
@@ -999,7 +1000,7 @@ mod tests {
         chain
     }
 
-    fn create_block(chain: &Chain, privkey: &cita_ed25519::PrivKey, to: Address, data: Vec<u8>, nonce: (u32, u32)) -> Block {
+    fn create_block(chain: &Chain, privkey: &PrivKey, to: Address, data: Vec<u8>, nonce: (u32, u32)) -> Block {
         let mut block = Block::new();
 
         block.set_parent_hash(chain.get_current_hash());
@@ -1071,7 +1072,7 @@ mod tests {
 
     #[test]
     fn test_code_at() {
-        let keypair = cita_ed25519::KeyPair::gen_keypair();
+        let keypair = KeyPair::gen_keypair();
         let privkey = keypair.privkey();
         let chain = init_chain();
         /*
@@ -1124,13 +1125,12 @@ mod tests {
 
     #[test]
     fn test_contract() {
-        //let keypair = cita_ed25519::KeyPair::gen_keypair();
+        //let keypair = KeyPair::gen_keypair();
         //let privkey = keypair.privkey();
         //let pubkey = keypair.pubkey();
-        let privkey = cita_ed25519::PrivKey::from("fc8937b92a38faf0196bdac328723c52da0e810f78d257c9ca8c0e304d6a3ad5bf700d906baec07f766b6492bea4223ed2bcbcfd978661983b8af4bc115d2d66");
-        let pubkey = cita_ed25519::PubKey::from("bf700d906baec07f766b6492bea4223ed2bcbcfd978661983b8af4bc115d2d66");
+        let privkey = PrivKey::from("fc8937b92a38faf0196bdac328723c52da0e810f78d257c9ca8c0e304d6a3ad5bf700d906baec07f766b6492bea4223ed2bcbcfd978661983b8af4bc115d2d66");
+        //let pubkey = PubKey::from("bf700d906baec07f766b6492bea4223ed2bcbcfd978661983b8af4bc115d2d66");
         println!("privkey: {:?}", privkey);
-        println!("pubkey: {:?}", pubkey);
         let chain = init_chain();
 
         /*

--- a/chain/core/src/state/mod.rs
+++ b/chain/core/src/state/mod.rs
@@ -702,7 +702,7 @@ impl Clone for State<StateDB> {
 #[cfg(test)]
 mod tests {
     extern crate libproto;
-    extern crate cita_ed25519;
+    extern crate cita_ed25519 as ed25519;
     extern crate protobuf;
     extern crate env_logger;
     ////////////////////////////////////////////////////////////////////////////////
@@ -713,7 +713,7 @@ mod tests {
     use rustc_hex::FromHex;
     use std::sync::Arc;
     use tests::helpers::*;
-    use util::{H256, H512, Address};
+    use util::{H256, Address};
     use util::hashable::HASH_NAME;
 
     #[test]
@@ -754,10 +754,11 @@ mod tests {
         uv_tx.set_transaction(tx);
 
         // 2) stx = (from, content(code, nonce, signature))
-        let privkey = cita_ed25519::PrivKey::from(H512::random());
+        let keypair = ed25519::KeyPair::gen_keypair();
+        let privkey = keypair.privkey();
         let mut stx = blockchain::SignedTransaction::new();
         stx.set_transaction_with_sig(uv_tx);
-        stx.sign(privkey);
+        stx.sign(*privkey);
 
         // 4) signed
         let signed = SignedTransaction::new(&stx).unwrap();

--- a/chain/core/src/state/mod.rs
+++ b/chain/core/src/state/mod.rs
@@ -702,18 +702,20 @@ impl Clone for State<StateDB> {
 #[cfg(test)]
 mod tests {
     extern crate libproto;
-    extern crate cita_ed25519 as ed25519;
+    extern crate cita_crypto;
     extern crate protobuf;
     extern crate env_logger;
     ////////////////////////////////////////////////////////////////////////////////
 
     use self::libproto::blockchain;
     use super::*;
+    use cita_crypto::KeyPair;
     use env_info::EnvInfo;
     use rustc_hex::FromHex;
     use std::sync::Arc;
     use tests::helpers::*;
     use util::{H256, Address};
+    use util::crypto::CreateKey;
     use util::hashable::HASH_NAME;
 
     #[test]
@@ -754,7 +756,7 @@ mod tests {
         uv_tx.set_transaction(tx);
 
         // 2) stx = (from, content(code, nonce, signature))
-        let keypair = ed25519::KeyPair::gen_keypair();
+        let keypair = KeyPair::gen_keypair();
         let privkey = keypair.privkey();
         let mut stx = blockchain::SignedTransaction::new();
         stx.set_transaction_with_sig(uv_tx);

--- a/chain/types/Cargo.toml
+++ b/chain/types/Cargo.toml
@@ -8,6 +8,6 @@ authors = ["Cryptape"]
 rlp = { path = "../../share_libs/rlp" }
 util = { path = "../../share_libs/util" }
 bloomable = { path = "../../share_libs/bloomable" }
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 libproto = { path = "../../share_libs/proto" }
 rustc-hex = "1.0"

--- a/chain/types/src/lib.rs
+++ b/chain/types/src/lib.rs
@@ -18,7 +18,7 @@
 extern crate util;
 extern crate rlp;
 extern crate bloomable;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 extern crate libproto;
 extern crate rustc_hex;
 pub mod account_diff;

--- a/chain/types/src/transaction.rs
+++ b/chain/types/src/transaction.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use BlockNumber;
-use ed25519::{Signature, Public, pubkey_to_address, SIGNATURE_BYTES_LEN, HASH_BYTES_LEN, PUBKEY_BYTES_LEN, PubKey};
+use crypto::{Signature, Public, pubkey_to_address, SIGNATURE_BYTES_LEN, HASH_BYTES_LEN, PUBKEY_BYTES_LEN, PubKey};
 use libproto::blockchain::{Transaction as ProtoTransaction, UnverifiedTransaction as ProtoUnverifiedTransaction, SignedTransaction as ProtoSignedTransaction, Crypto as ProtoCrypto};
 use rlp::*;
 use std::ops::{Deref, DerefMut};
@@ -353,7 +353,7 @@ impl Decodable for SignedTransaction {
             return Err(DecoderError::RlpIncorrectListLen);
         }
 
-        let public: PubKey = d.val_at(4)?;
+        let public: PubKey = d.val_at(10)?;
 
         Ok(SignedTransaction {
                transaction: UnverifiedTransaction {

--- a/chain/types/src/transaction.rs
+++ b/chain/types/src/transaction.rs
@@ -16,12 +16,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use BlockNumber;
-use ed25519::{Signature, Public, pubkey_to_address, SIGNATURE_BYTES_LEN, HASH_BYTES_LEN, PUBKEY_BYTES_LEN};
+use ed25519::{Signature, Public, pubkey_to_address, SIGNATURE_BYTES_LEN, HASH_BYTES_LEN, PUBKEY_BYTES_LEN, PubKey};
 use libproto::blockchain::{Transaction as ProtoTransaction, UnverifiedTransaction as ProtoUnverifiedTransaction, SignedTransaction as ProtoSignedTransaction, Crypto as ProtoCrypto};
 use rlp::*;
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
-use util::{H256, Address, U256, Bytes, HeapSizeOf, H768};
+use util::{H256, Address, U256, Bytes, HeapSizeOf};
 
 // pub const STORE_ADDRESS: H160 =  H160( [0xff; 20] );
 pub const STORE_ADDRESS: &str = "ffffffffffffffffffffffffffffffffffffffff";
@@ -298,7 +298,7 @@ impl UnverifiedTransaction {
 
         Ok(UnverifiedTransaction {
                unsigned: Transaction::new(utx.get_transaction())?,
-               signature: Signature::from(H768::from(utx.get_signature())),
+               signature: Signature::from(utx.get_signature()),
                crypto_type: CryptoType::from(utx.get_crypto()),
                hash: hash,
            })
@@ -353,7 +353,7 @@ impl Decodable for SignedTransaction {
             return Err(DecoderError::RlpIncorrectListLen);
         }
 
-        let public: H256 = d.val_at(10)?;
+        let public: PubKey = d.val_at(4)?;
 
         Ok(SignedTransaction {
                transaction: UnverifiedTransaction {
@@ -428,7 +428,7 @@ impl SignedTransaction {
         }
 
         let tx_hash = H256::from(stx.get_tx_hash());
-        let public = H256::from_slice(stx.get_signer());
+        let public = PubKey::from_slice(stx.get_signer());
         let sender = pubkey_to_address(&public);
         Ok(SignedTransaction {
                transaction: UnverifiedTransaction::new(stx.get_transaction_with_sig(), tx_hash)?,

--- a/consensus/authority_round/Cargo.toml
+++ b/consensus/authority_round/Cargo.toml
@@ -12,7 +12,7 @@ util = {path = "../../share_libs/util"}
 tx_pool = {path = "../../share_libs/tx_pool"}
 rustc-serialize = "0.3"
 protobuf = { version = "^1.0.0" }
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 engine_json = { path = "../json" }
 engine = { path = "../engine" }
 proof = { path = "../proof" }

--- a/consensus/authority_round/src/core/authority_round.rs
+++ b/consensus/authority_round/src/core/authority_round.rs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{Engine, EngineError, Signable, unix_now, AsMillis};
-use ed25519::{Signature, Signer};
+use crypto::{Signature, Signer, CreateKey};
 use engine_json;
 use libproto::*;
 use libproto::blockchain::{BlockBody, Proof, Block, SignedTransaction, Status};
@@ -89,7 +89,7 @@ impl AuthorityRound {
     }
 
     pub fn generate_proof(&self, body: &mut BlockBody, step: u64) -> Proof {
-        let signature = body.sign_with_privkey(self.params.signer.privkey()).unwrap();
+        let signature = body.sign_with_privkey(self.params.signer.keypair.privkey()).unwrap();
         let proof: Proof = AuthorityRoundProof::new(step, signature).into();
         proof
     }

--- a/consensus/authority_round/src/core/mod.rs
+++ b/consensus/authority_round/src/core/mod.rs
@@ -21,7 +21,7 @@ pub mod spec;
 
 pub use self::authority_round::AuthorityRound;
 pub use self::spec::Spec;
-use ed25519::{PrivKey, Signature, sign, recover, pubkey_to_address, Error as CryptoError};
+use crypto::{PrivKey, Signature, Sign, pubkey_to_address, Error as CryptoError};
 pub use engine::*;
 pub use libproto::blockchain::{BlockHeader, Block, Transaction, BlockBody, Proof};
 use util::Address;
@@ -30,10 +30,10 @@ use util::H256;
 pub trait Signable {
     fn bare_hash(&self) -> H256;
     fn sign_with_privkey(&self, privkey: &PrivKey) -> Result<Signature, CryptoError> {
-        sign(privkey, &self.bare_hash().into())
+        Signature::sign(privkey, &self.bare_hash().into())
     }
     fn recover_address_with_signature(&self, signature: &Signature) -> Result<Address, CryptoError> {
-        let pubkey = recover(signature, &self.bare_hash().into()).unwrap();
+        let pubkey = signature.recover(&self.bare_hash().into()).unwrap();
         Ok(pubkey_to_address(&pubkey).into())
     }
 }

--- a/consensus/authority_round/src/main.rs
+++ b/consensus/authority_round/src/main.rs
@@ -24,7 +24,7 @@ extern crate protobuf;
 extern crate log;
 extern crate clap;
 extern crate tx_pool;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 extern crate proof;
 extern crate pubsub;
 extern crate engine_json;

--- a/consensus/engine/Cargo.toml
+++ b/consensus/engine/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["zhangsoledad <787953403@qq.com>"]
 libproto = {path = "../../share_libs/proto"}
 util = {path = "../../share_libs/util"}
 protobuf = { version = "^1.0.0" }
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 engine_json = { path = "../json" }
 proof = { path = "../proof" }
 pubsub = { path = "../../share_libs/pubsub" }

--- a/consensus/engine/src/error.rs
+++ b/consensus/engine/src/error.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use ed25519::Signature;
+use crypto::Signature;
 use std::fmt;
 use util::Address;
 

--- a/consensus/engine/src/lib.rs
+++ b/consensus/engine/src/lib.rs
@@ -17,7 +17,7 @@
 
 extern crate libproto;
 extern crate util;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 
 mod error;
 mod instrument;

--- a/consensus/json/Cargo.toml
+++ b/consensus/json/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["zhangsoledad <787953403@qq.com>"]
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 util = {path = "../../share_libs/util"}

--- a/consensus/json/src/authority_round.rs
+++ b/consensus/json/src/authority_round.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use ed25519::PrivKey;
+use crypto::PrivKey;
 use util::Address;
 
 /// Authority params deserialization.

--- a/consensus/json/src/lib.rs
+++ b/consensus/json/src/lib.rs
@@ -20,7 +20,7 @@
 extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 extern crate util;
 
 mod engine;

--- a/consensus/json/src/tendermint.rs
+++ b/consensus/json/src/tendermint.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use ed25519::PrivKey;
+use crypto::PrivKey;
 use util::Address;
 
 /// Authority params deserialization.

--- a/consensus/proof/Cargo.toml
+++ b/consensus/proof/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["zhangsoledad <787953403@qq.com>"]
 
 [dependencies]
 libproto = {path = "../../share_libs/proto"}
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/consensus/proof/src/authority_round_proof.rs
+++ b/consensus/proof/src/authority_round_proof.rs
@@ -24,7 +24,7 @@ use util::H768;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct AuthorityRoundProof {
-    pub signature: H768,
+    pub signature: Signature,
     pub step: u64,
 }
 
@@ -32,7 +32,7 @@ impl AuthorityRoundProof {
     pub fn new(step: u64, signature: Signature) -> AuthorityRoundProof {
         AuthorityRoundProof {
             step: step,
-            signature: H768::from(signature.0).into(),
+            signature: signature,
         }
     }
 }

--- a/consensus/proof/src/authority_round_proof.rs
+++ b/consensus/proof/src/authority_round_proof.rs
@@ -16,11 +16,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use bincode::{serialize, deserialize, Infinite};
-use ed25519::Signature;
+use crypto::Signature;
 use libproto::blockchain::{Proof, ProofType};
 use rustc_serialize::hex::ToHex;
 use std::fmt;
-use util::H768;
 
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug)]
 pub struct AuthorityRoundProof {
@@ -30,10 +29,7 @@ pub struct AuthorityRoundProof {
 
 impl AuthorityRoundProof {
     pub fn new(step: u64, signature: Signature) -> AuthorityRoundProof {
-        AuthorityRoundProof {
-            step: step,
-            signature: signature,
-        }
+        AuthorityRoundProof { step: step, signature: signature }
     }
 }
 

--- a/consensus/proof/src/lib.rs
+++ b/consensus/proof/src/lib.rs
@@ -18,7 +18,7 @@
 extern crate libproto;
 extern crate util;
 extern crate bincode;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 extern crate rustc_serialize;
 #[macro_use]
 extern crate serde_derive;
@@ -68,7 +68,7 @@ mod tests {
     use super::CitaProof;
     use super::authority_round_proof::AuthorityRoundProof;
     use super::tendermint_proof::TendermintProof;
-    use ed25519::Signature;
+    use crypto::Signature;
     use libproto::blockchain::Proof;
     use std::collections::HashMap;
     use util::*;

--- a/consensus/proof/src/tendermint_proof.rs
+++ b/consensus/proof/src/tendermint_proof.rs
@@ -18,6 +18,7 @@
 use bincode::{serialize, deserialize, Infinite};
 use ed25519::{Signature, recover, pubkey_to_address};
 use libproto::blockchain::{Proof, ProofType};
+use util::{H256, Address};
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -40,11 +41,11 @@ pub struct TendermintProof {
     pub proposal: H256,
     pub height: usize,
     pub round: usize,
-    pub commits: HashMap<Address, H768>,
+    pub commits: HashMap<Address, Signature>,
 }
 
 impl TendermintProof {
-    pub fn new(height: usize, round: usize, proposal: H256, commits: HashMap<Address, H768>) -> TendermintProof {
+    pub fn new(height: usize, round: usize, proposal: H256, commits: HashMap<Address, Signature>) -> TendermintProof {
         TendermintProof {
             height: height,
             round: round,

--- a/consensus/tdmint/Cargo.toml
+++ b/consensus/tdmint/Cargo.toml
@@ -16,7 +16,6 @@ rustc-serialize = "0.3"
 tx_pool = {path = "../../share_libs/tx_pool"}
 protobuf = { version = "^1.0.0" }
 log = "0.3"
-eth-secp256k1 = { git = "https://github.com/ethcore/rust-secp256k1" }
 clap = "2"
 amqp = "=0.0.20"
 pubsub = { path = "../../share_libs/pubsub" }

--- a/consensus/tdmint/Cargo.toml
+++ b/consensus/tdmint/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.3"
 clap = "2"
 amqp = "=0.0.20"
 pubsub = { path = "../../share_libs/pubsub" }
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 proof = { path = "../proof" }
 parking_lot = "0.4"
 time = "0.1.36"

--- a/consensus/tdmint/src/core/params.rs
+++ b/consensus/tdmint/src/core/params.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use ed25519::Signer;
+use crypto::Signer;
 use engine_json;
 use std::time::Duration;
 use util::Address;

--- a/consensus/tdmint/src/core/voteset.rs
+++ b/consensus/tdmint/src/core/voteset.rs
@@ -17,13 +17,12 @@
 
 use super::{Step, Address};
 use bincode::{serialize, Infinite};
-use ed25519::{recover, pubkey_to_address};
+use ed25519::{recover, pubkey_to_address, Signature};
 use libproto::blockchain::Block;
 use lru_cache::LruCache;
 use protobuf::core::parse_from_bytes;
 use std::collections::HashMap;
-use util::{H256, H768};
-use util::Hashable;
+use util::{H256, Hashable};
 
 //height -> round collector
 #[derive(Debug)]
@@ -159,7 +158,7 @@ impl VoteSet {
         for (sender, vote) in &self.votes_by_sender {
             if authorities.contains(sender) {
                 let msg = serialize(&(h, r, step, sender, vote.proposal), Infinite).unwrap();
-                if let Ok(pubkey) = recover(&vote.signature.into(), &msg.crypt_hash().into()) {
+                if let Ok(pubkey) = recover(&vote.signature, &msg.crypt_hash().into()) {
                     if pubkey_to_address(&pubkey) == sender.clone() {
                         let mut hash = H256::default();
                         if let Some(h) = vote.proposal {
@@ -190,7 +189,7 @@ impl VoteSet {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct VoteMessage {
     pub proposal: Option<H256>,
-    pub signature: H768,
+    pub signature: Signature,
 }
 
 #[derive(Debug)]

--- a/consensus/tdmint/src/core/voteset.rs
+++ b/consensus/tdmint/src/core/voteset.rs
@@ -17,7 +17,7 @@
 
 use super::{Step, Address};
 use bincode::{serialize, Infinite};
-use ed25519::{recover, pubkey_to_address, Signature};
+use crypto::{Sign, pubkey_to_address, Signature};
 use libproto::blockchain::Block;
 use lru_cache::LruCache;
 use protobuf::core::parse_from_bytes;
@@ -158,7 +158,8 @@ impl VoteSet {
         for (sender, vote) in &self.votes_by_sender {
             if authorities.contains(sender) {
                 let msg = serialize(&(h, r, step, sender, vote.proposal), Infinite).unwrap();
-                if let Ok(pubkey) = recover(&vote.signature, &msg.crypt_hash().into()) {
+                let signature = &vote.signature;
+                if let Ok(pubkey) = signature.recover(&msg.crypt_hash().into()) {
                     if pubkey_to_address(&pubkey) == sender.clone() {
                         let mut hash = H256::default();
                         if let Some(h) = vote.proposal {

--- a/consensus/tdmint/src/main.rs
+++ b/consensus/tdmint/src/main.rs
@@ -26,7 +26,7 @@ extern crate protobuf;
 extern crate log;
 extern crate clap;
 extern crate tx_pool;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 extern crate proof;
 extern crate pubsub;
 extern crate bincode;

--- a/share_libs/bigint/src/hash.rs
+++ b/share_libs/bigint/src/hash.rs
@@ -495,12 +495,11 @@ impl_serde_for_bigint!(H160);
 impl_serde_for_bigint!(H256);
 impl_serde_for_bigint!(H512);
 impl_serde_for_bigint!(H520);
-impl_serde_for_bigint!(H768);
 impl_serde_for_bigint!(H2048);
 impl_serde_for_bigint!(U256);
 
 #[cfg(feature = "heapsizeof")]
-known_heap_size!(0, H32, H64, H128, H160, H256, H264, H512, H520, H768, H1024, H2048);
+known_heap_size!(0, H32, H64, H128, H160, H256, H264, H512, H520, H1024, H2048);
 // Specialized HashMap and HashSet
 
 /// Hasher that just takes 8 bytes of the provided value.

--- a/share_libs/crypto/Cargo.toml
+++ b/share_libs/crypto/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cita-crypto"
+version = "0.1.0"
+authors = ["lbqds <lbqds@cryptape.com>"]
+
+[dependencies]
+cita-ed25519 = { path = "../ed25519", optional = true }
+cita-secp256k1 = { path = "../secp256k1", optional = true }
+util = { path = "../util" }
+
+[features]
+default = ["ed25519"]
+ed25519 = ["cita-ed25519"]
+secp256k1 = ["cita-secp256k1"]

--- a/share_libs/crypto/src/lib.rs
+++ b/share_libs/crypto/src/lib.rs
@@ -1,0 +1,11 @@
+#[cfg(feature = "ed25519")]
+extern crate cita_ed25519;
+#[cfg(feature = "secp256k1")]
+extern crate cita_secp256k1;
+extern crate util;
+
+#[cfg(feature = "ed25519")]
+pub use cita_ed25519::*;
+#[cfg(feature = "secp256k1")]
+pub use cita_secp256k1::*;
+pub use util::crypto::{Sign, CreateKey};

--- a/share_libs/ed25519/Cargo.toml
+++ b/share_libs/ed25519/Cargo.toml
@@ -6,5 +6,7 @@ authors = ["wangyifu <lbqds@cryptape.com>"]
 [dependencies]
 rustc-serialize = "0.3"
 sodiumoxide = { git = "https://github.com/cryptape/sodiumoxide.git" }
-util = { path = "../../share_libs/util" }
+util = { path = "../util" }
 rlp = { path = "../rlp" }
+serde = "1.0"
+bincode = "0.8.0"

--- a/share_libs/ed25519/src/keypair.rs
+++ b/share_libs/ed25519/src/keypair.rs
@@ -1,6 +1,9 @@
+
 use super::{PrivKey, PubKey, Address};
 use error::Error;
+use rustc_serialize::hex::ToHex;
 use sodiumoxide::crypto::sign::{keypair_from_privkey, gen_keypair};
+use std::fmt;
 use util::{H160, Hashable};
 
 pub fn pubkey_to_address(pubkey: &PubKey) -> Address {
@@ -11,6 +14,14 @@ pub fn pubkey_to_address(pubkey: &PubKey) -> Address {
 pub struct KeyPair {
     privkey: PrivKey,
     pubkey: PubKey,
+}
+
+impl fmt::Display for KeyPair {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        writeln!(f, "privkey:  {}", self.privkey.0.to_hex())?;
+        writeln!(f, "pubkey:  {}", self.pubkey.0.to_hex())?;
+        write!(f, "address:  {}", self.address().0.to_hex())
+    }
 }
 
 impl KeyPair {

--- a/share_libs/ed25519/src/keypair.rs
+++ b/share_libs/ed25519/src/keypair.rs
@@ -1,10 +1,10 @@
-
 use super::{PrivKey, PubKey, Address};
 use error::Error;
 use rustc_serialize::hex::ToHex;
 use sodiumoxide::crypto::sign::{keypair_from_privkey, gen_keypair};
 use std::fmt;
 use util::{H160, Hashable};
+use util::crypto::CreateKey;
 
 pub fn pubkey_to_address(pubkey: &PubKey) -> Address {
     Address::from(H160::from(pubkey.crypt_hash()))
@@ -24,8 +24,12 @@ impl fmt::Display for KeyPair {
     }
 }
 
-impl KeyPair {
-    pub fn from_privkey(privkey: PrivKey) -> Result<Self, Error> {
+impl CreateKey for KeyPair {
+    type PrivKey = PrivKey;
+    type PubKey = PubKey;
+    type Error = Error;
+
+    fn from_privkey(privkey: Self::PrivKey) -> Result<Self, Self::Error> {
         let keypair = keypair_from_privkey(privkey.as_ref());
         match keypair {
             None => Err(Error::InvalidPrivKey),
@@ -36,7 +40,7 @@ impl KeyPair {
         }
     }
 
-    pub fn gen_keypair() -> Self {
+    fn gen_keypair() -> Self {
         let (pk, sk) = gen_keypair();
         KeyPair {
             privkey: PrivKey::from(sk.0),
@@ -44,15 +48,15 @@ impl KeyPair {
         }
     }
 
-    pub fn privkey(&self) -> &PrivKey {
+    fn privkey(&self) -> &Self::PrivKey {
         &self.privkey
     }
 
-    pub fn pubkey(&self) -> &PubKey {
+    fn pubkey(&self) -> &Self::PubKey {
         &self.pubkey
     }
 
-    pub fn address(&self) -> Address {
+    fn address(&self) -> Address {
         pubkey_to_address(&self.pubkey)
     }
 }
@@ -60,6 +64,7 @@ impl KeyPair {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use util::crypto::CreateKey;
 
     #[test]
     fn test_from_privkey() {

--- a/share_libs/ed25519/src/lib.rs
+++ b/share_libs/ed25519/src/lib.rs
@@ -2,6 +2,9 @@ extern crate sodiumoxide;
 extern crate rustc_serialize;
 extern crate util;
 extern crate rlp;
+extern crate serde;
+#[cfg(test)]
+extern crate bincode;
 
 mod keypair;
 mod error;

--- a/share_libs/ed25519/src/signer.rs
+++ b/share_libs/ed25519/src/signer.rs
@@ -1,19 +1,10 @@
-use super::{PubKey, PrivKey, KeyPair, Address};
+use super::{PrivKey, KeyPair, Address};
+use util::crypto::CreateKey;
 
 #[derive(Default)]
 pub struct Signer {
     pub keypair: KeyPair,
     pub address: Address,
-}
-
-impl Signer {
-    pub fn privkey(&self) -> &PrivKey {
-        self.keypair.privkey()
-    }
-
-    pub fn pubkey(&self) -> &PubKey {
-        self.keypair.pubkey()
-    }
 }
 
 impl From<PrivKey> for Signer {
@@ -29,6 +20,7 @@ impl From<PrivKey> for Signer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use util::crypto::CreateKey;
 
     #[test]
     fn test_signer() {

--- a/share_libs/proto/Cargo.toml
+++ b/share_libs/proto/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["gguoss"]
 
 [dependencies]
 protobuf = { version = "^1.0.0"}
-cita-ed25519 = { path = "../ed25519"}
+cita-crypto = { path = "../crypto"}
 util = { path = "../util"}
 rustc-serialize = "0.3"
 rlp = { path = "../rlp"}

--- a/share_libs/proto/src/lib.rs
+++ b/share_libs/proto/src/lib.rs
@@ -30,13 +30,13 @@ pub mod into;
 
 use blockchain::*;
 use communication::*;
-use ed25519::{sign, PrivKey, recover, Signature, KeyPair, SIGNATURE_BYTES_LEN};
+use ed25519::{sign, PrivKey, recover, Signature, KeyPair, SIGNATURE_BYTES_LEN, Message as SignMessage};
 use protobuf::Message;
 use protobuf::core::parse_from_bytes;
 pub use request::*;
 use rlp::*;
 use rustc_serialize::hex::ToHex;
-use util::{H256, Hashable, H768, merklehash};
+use util::{H256, Hashable, merklehash};
 use util::snappy;
 
 #[derive(Serialize, Deserialize, PartialEq)]
@@ -200,7 +200,7 @@ impl blockchain::SignedTransaction {
 
         let bytes = self.get_transaction_with_sig().get_transaction().write_to_bytes().unwrap();
         let hash = bytes.crypt_hash();
-        let signature = sign(&sk, &H256::from(hash)).unwrap();
+        let signature = sign(&sk, &SignMessage::from(hash)).unwrap();
         self.mut_transaction_with_sig().set_signature(signature.to_vec());
         self.mut_transaction_with_sig().set_crypto(Crypto::SECP);
         self.set_signer(pubkey.to_vec());
@@ -217,7 +217,7 @@ impl blockchain::SignedTransaction {
         } else {
             match self.get_transaction_with_sig().get_crypto() {
                 Crypto::SECP => {
-                    let signature: Signature = H768::from_slice(self.get_transaction_with_sig().get_signature()).into();
+                    let signature = Signature::from(self.get_transaction_with_sig().get_signature());
                     match recover(&signature, &hash) {
                         Ok(pubkey) => {
                             self.set_signer(pubkey.to_vec());

--- a/share_libs/proto/src/lib.rs
+++ b/share_libs/proto/src/lib.rs
@@ -21,7 +21,7 @@ extern crate rustc_serialize;
 extern crate rlp;
 #[macro_use]
 extern crate serde_derive;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 
 pub mod blockchain;
 pub mod communication;
@@ -30,7 +30,7 @@ pub mod into;
 
 use blockchain::*;
 use communication::*;
-use ed25519::{sign, PrivKey, recover, Signature, KeyPair, SIGNATURE_BYTES_LEN, Message as SignMessage};
+use crypto::{PrivKey, Signature, KeyPair, SIGNATURE_BYTES_LEN, Message as SignMessage, CreateKey, Sign};
 use protobuf::Message;
 use protobuf::core::parse_from_bytes;
 pub use request::*;
@@ -200,7 +200,7 @@ impl blockchain::SignedTransaction {
 
         let bytes = self.get_transaction_with_sig().get_transaction().write_to_bytes().unwrap();
         let hash = bytes.crypt_hash();
-        let signature = sign(&sk, &SignMessage::from(hash)).unwrap();
+        let signature = Signature::sign(&sk, &SignMessage::from(hash)).unwrap();
         self.mut_transaction_with_sig().set_signature(signature.to_vec());
         self.mut_transaction_with_sig().set_crypto(Crypto::SECP);
         self.set_signer(pubkey.to_vec());
@@ -218,7 +218,7 @@ impl blockchain::SignedTransaction {
             match self.get_transaction_with_sig().get_crypto() {
                 Crypto::SECP => {
                     let signature = Signature::from(self.get_transaction_with_sig().get_signature());
-                    match recover(&signature, &hash) {
+                    match signature.recover(&hash) {
                         Ok(pubkey) => {
                             self.set_signer(pubkey.to_vec());
                         }

--- a/share_libs/secp256k1/Cargo.toml
+++ b/share_libs/secp256k1/Cargo.toml
@@ -8,6 +8,8 @@ eth-secp256k1 = { git = "https://github.com/ethcore/rust-secp256k1" }
 lazy_static = "0.2"
 rustc-serialize = "0.3"
 util = {path = "../../share_libs/util"}
+rlp = { path = "../rlp" }
 rand = "0.3"
 serde = "1.0"
 serde_json = "1.0"
+bincode = "0.8"

--- a/share_libs/secp256k1/src/keypair.rs
+++ b/share_libs/secp256k1/src/keypair.rs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::{PrivKey, PubKey, Address, SECP256K1, Error};
+use rand::thread_rng;
 use rustc_serialize::hex::ToHex;
 use secp256k1::key;
 use std::fmt;
@@ -57,14 +58,14 @@ impl KeyPair {
         Ok(keypair)
     }
 
-    pub fn from_keypair(sec: key::SecretKey, publ: key::PublicKey) -> Self {
+    pub fn gen_keypair() -> Self {
         let context = &SECP256K1;
-        let serialized = publ.serialize_vec(context, false);
+        let (s, p) = context.generate_keypair(&mut thread_rng()).unwrap();
+        let serialized = p.serialize_vec(context, false);
         let mut privkey = PrivKey::default();
-        privkey.0.copy_from_slice(&sec[0..32]);
+        privkey.0.copy_from_slice(&s[0..32]);
         let mut pubkey = PubKey::default();
         pubkey.0.copy_from_slice(&serialized[1..65]);
-
         KeyPair { privkey: privkey, pubkey: pubkey }
     }
 

--- a/share_libs/secp256k1/src/lib.rs
+++ b/share_libs/secp256k1/src/lib.rs
@@ -21,6 +21,10 @@ extern crate secp256k1;
 extern crate rustc_serialize;
 extern crate util;
 extern crate rand;
+extern crate rlp;
+extern crate serde;
+#[cfg(test)]
+extern crate bincode;
 
 pub type PrivKey = H256;
 pub type PubKey = H512;
@@ -43,7 +47,6 @@ pub use self::keypair::*;
 pub use self::signature::*;
 pub use self::signer::Signer;
 use util::{H256, H512, Address};
-
 
 lazy_static! {
     pub static ref SECP256K1: secp256k1::Secp256k1 = secp256k1::Secp256k1::new();

--- a/share_libs/secp256k1/src/signer.rs
+++ b/share_libs/secp256k1/src/signer.rs
@@ -15,22 +15,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::{PrivKey, KeyPair, PubKey, Address};
+use super::{PrivKey, KeyPair, Address};
+use util::crypto::CreateKey;
 
 #[derive(Default)]
 pub struct Signer {
     pub keypair: KeyPair,
     pub address: Address,
-}
-
-impl Signer {
-    pub fn privkey(&self) -> &PrivKey {
-        self.keypair.privkey()
-    }
-
-    pub fn pubkey(&self) -> &PubKey {
-        self.keypair.pubkey()
-    }
 }
 
 impl From<PrivKey> for Signer {

--- a/share_libs/tx_pool/Cargo.toml
+++ b/share_libs/tx_pool/Cargo.toml
@@ -7,4 +7,4 @@ authors = ["rink1969 <rink1969@cryptape.com>"]
 lru-cache = "0.1"
 libproto = { path = "../proto" }
 util = { path = "../util" }
-cita-ed25519 = { path = "../ed25519" }
+cita-crypto = { path = "../crypto" }

--- a/share_libs/tx_pool/benches/bench.rs
+++ b/share_libs/tx_pool/benches/bench.rs
@@ -21,9 +21,9 @@ extern crate tx_pool;
 extern crate test;
 extern crate libproto;
 extern crate util;
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 
-use ed25519::KeyPair;
+use crypto::{KeyPair, CreateKey};
 use libproto::blockchain::{Transaction, UnverifiedTransaction, SignedTransaction};
 use std::time::SystemTime;
 use test::Bencher;

--- a/share_libs/tx_pool/src/filter.rs
+++ b/share_libs/tx_pool/src/filter.rs
@@ -40,9 +40,8 @@ impl Filter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ed25519::{KeyPair, PrivKey};
+    use crypto::{KeyPair, PrivKey, CreateKey};
     use libproto::blockchain::{SignedTransaction, UnverifiedTransaction, Transaction};
-    use util::H512;
 
     pub fn generate_tx(data: Vec<u8>, valid_until_block: u64, privkey: &PrivKey) -> SignedTransaction {
         let mut tx = Transaction::new();

--- a/share_libs/tx_pool/src/lib.rs
+++ b/share_libs/tx_pool/src/lib.rs
@@ -19,7 +19,7 @@ extern crate lru_cache;
 extern crate libproto;
 extern crate util;
 #[cfg(test)]
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 
 pub mod filter;
 pub mod pool;

--- a/share_libs/tx_pool/src/lib.rs
+++ b/share_libs/tx_pool/src/lib.rs
@@ -18,6 +18,8 @@
 extern crate lru_cache;
 extern crate libproto;
 extern crate util;
+#[cfg(test)]
+extern crate cita_ed25519 as ed25519;
 
 pub mod filter;
 pub mod pool;

--- a/share_libs/tx_pool/src/pool.rs
+++ b/share_libs/tx_pool/src/pool.rs
@@ -183,24 +183,23 @@ impl Pool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ed25519::{KeyPair, PrivKey};
     use libproto::blockchain::{SignedTransaction, UnverifiedTransaction, Transaction};
     use util::H512;
 
-    pub fn generate_tx(data: Vec<u8>, valid_until_block: u64) -> SignedTransaction {
+    pub fn generate_tx(data: Vec<u8>, valid_until_block: u64, privkey: &PrivKey) -> SignedTransaction {
         let mut tx = Transaction::new();
         tx.set_data(data);
         tx.set_to("1234567".to_string());
         tx.set_nonce("0".to_string());
         tx.set_valid_until_block(valid_until_block);
 
-        let pv = H512::from_slice(&[20, 17]);
-
         let mut uv_tx = UnverifiedTransaction::new();
         uv_tx.set_transaction(tx);
 
         let mut signed_tx = SignedTransaction::new();
         signed_tx.set_transaction_with_sig(uv_tx);
-        signed_tx.sign(pv);
+        signed_tx.sign(*privkey);
 
         signed_tx
     }
@@ -208,10 +207,13 @@ mod tests {
     #[test]
     fn basic() {
         let mut p = Pool::new(2, 1);
-        let tx1 = generate_tx(vec![1], 999);
-        let tx2 = generate_tx(vec![1], 999);
-        let tx3 = generate_tx(vec![2], 999);
-        let tx4 = generate_tx(vec![3], 5);
+        let keypair = KeyPair::gen_keypair();
+        let privkey = keypair.privkey();
+
+        let tx1 = generate_tx(vec![1], 999, privkey);
+        let tx2 = generate_tx(vec![1], 999, privkey);
+        let tx3 = generate_tx(vec![2], 999, privkey);
+        let tx4 = generate_tx(vec![3], 5, privkey);
 
         assert_eq!(p.enqueue(tx1.clone()), true);
         assert_eq!(p.enqueue(tx2.clone()), false);

--- a/share_libs/tx_pool/src/pool.rs
+++ b/share_libs/tx_pool/src/pool.rs
@@ -183,9 +183,8 @@ impl Pool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ed25519::{KeyPair, PrivKey};
+    use crypto::{KeyPair, PrivKey, CreateKey};
     use libproto::blockchain::{SignedTransaction, UnverifiedTransaction, Transaction};
-    use util::H512;
 
     pub fn generate_tx(data: Vec<u8>, valid_until_block: u64, privkey: &PrivKey) -> SignedTransaction {
         let mut tx = Transaction::new();

--- a/share_libs/util/src/crypto.rs
+++ b/share_libs/util/src/crypto.rs
@@ -1,0 +1,32 @@
+use super::Address;
+use std::marker;
+
+pub trait Sign
+where
+    Self: marker::Sized,
+{
+    type PrivKey;
+    type PubKey;
+    type Message;
+    type Error;
+
+    fn sign(privkey: &Self::PrivKey, message: &Self::Message) -> Result<Self, Self::Error>;
+    fn recover(&self, message: &Self::Message) -> Result<Self::PubKey, Self::Error>;
+    fn verify_public(&self, pubkey: &Self::PubKey, message: &Self::Message) -> Result<bool, Self::Error>;
+    fn verify_address(&self, address: &Address, message: &Self::Message) -> Result<bool, Self::Error>;
+}
+
+pub trait CreateKey
+where
+    Self: marker::Sized,
+{
+    type PrivKey;
+    type PubKey;
+    type Error;
+
+    fn from_privkey(privkey: Self::PrivKey) -> Result<Self, Self::Error>;
+    fn gen_keypair() -> Self;
+    fn privkey(&self) -> &Self::PrivKey;
+    fn pubkey(&self) -> &Self::PubKey;
+    fn address(&self) -> Address;
+}

--- a/share_libs/util/src/lib.rs
+++ b/share_libs/util/src/lib.rs
@@ -58,6 +58,7 @@ pub mod nibblevec;
 pub mod semantic_version;
 pub mod snappy;
 pub mod cache;
+pub mod crypto;
 
 
 pub use ansi_term::{Colour, Style};

--- a/tests/chain_performance/Cargo.toml
+++ b/tests/chain_performance/Cargo.toml
@@ -12,7 +12,7 @@ clap = "2"
 libproto = { path = "../../share_libs/proto"}
 protobuf = { version = "^1.0.0" }
 rustc-serialize = "0.3"
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 util = { path = "../../share_libs/util" }
 dotenv = "0.10.0"
 uuid = { version = "0.4", features = ["v4"] }

--- a/tests/chain_performance/src/generate_block.rs
+++ b/tests/chain_performance/src/generate_block.rs
@@ -18,7 +18,7 @@
 use bincode::{serialize, Infinite};
 use core::libchain::block::Block;
 use core::transaction::SignedTransaction;
-use ed25519::*;
+use crypto::*;
 use libproto::{factory, communication, topics, submodules};
 use libproto::blockchain::{SignedTransaction as ProtoSignedTransaction, UnverifiedTransaction, Transaction};
 use proof::TendermintProof;
@@ -104,7 +104,7 @@ impl Generateblock {
         proof.proposal = H256::default();
         let mut commits = HashMap::new();
         let msg = serialize(&(proof.height, proof.round, Step::Precommit, sender.clone(), Some(proof.proposal.clone())), Infinite).unwrap();
-        let signature = sign(pv, &msg.crypt_hash().into()).unwrap();
+        let signature = Signature::sign(pv, &msg.crypt_hash().into()).unwrap();
         commits.insert((*sender).into(), signature.into());
         proof.commits = commits;
         block.set_proof(proof.into());

--- a/tests/chain_performance/src/main.rs
+++ b/tests/chain_performance/src/main.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 extern crate libproto;
 extern crate protobuf;
 extern crate util;

--- a/tests/trans_evm/Cargo.toml
+++ b/tests/trans_evm/Cargo.toml
@@ -10,7 +10,7 @@ serde_json = "1.0"
 clap = "2"
 libproto = { path = "../../share_libs/proto"}
 protobuf = { version = "^1.0.0" }
-cita-ed25519 = { path = "../../share_libs/ed25519" }
+cita-crypto = { path = "../../share_libs/crypto" }
 util = { path = "../../share_libs/util" }
 dotenv = "0.10.0"
 hyper =  "0.10.7"

--- a/tests/trans_evm/src/core/send_trans.rs
+++ b/tests/trans_evm/src/core/send_trans.rs
@@ -89,7 +89,7 @@ impl Sendtx {
             Err(_) => panic!("read fail "),
             Ok(_) => println!("read successfully.[{}]", contents),
         }
-        let privkey = H512::from_str(contents.as_str()).unwrap();
+        let privkey = PrivKey::from_str(contents.as_str()).unwrap();
         KeyPair::from_privkey(privkey)
     }
 

--- a/tests/trans_evm/src/core/send_trans.rs
+++ b/tests/trans_evm/src/core/send_trans.rs
@@ -17,7 +17,7 @@
 
 use core::param::Param;
 use core::trans::*;
-use ed25519::*;
+use crypto::*;
 use hyper::Client;
 use hyper::client::Response;
 use hyper::status::StatusCode;
@@ -33,7 +33,6 @@ use std::sync::{Arc, Mutex};
 use std::sync::mpsc;
 use std::thread;
 use std::time;
-use util::H512;
 
 static mut EXIT: bool = false;
 #[allow(dead_code, unused_assignments)]

--- a/tests/trans_evm/src/core/trans.rs
+++ b/tests/trans_evm/src/core/trans.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use ed25519::*;
+use crypto::*;
 use libproto::blockchain::{SignedTransaction, UnverifiedTransaction, Transaction};
 use protobuf::core::Message;
 use rustc_hex::FromHex;

--- a/tests/trans_evm/src/main.rs
+++ b/tests/trans_evm/src/main.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #![allow(unused_extern_crates)]
-extern crate cita_ed25519 as ed25519;
+extern crate cita_crypto as crypto;
 extern crate libproto;
 extern crate protobuf;
 extern crate util;


### PR DESCRIPTION
签名序列化、反序列化，修改直接使用H256, H512, H768生成公私钥和签名
增加crypo lib，签名算法可配置