### PR TITLE
Update setup script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
 name = "auth"
 version = "0.1.0"
 dependencies = [
+ "cache_2q 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita_log 0.1.0",
  "clap 2.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cpuprofiler 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -269,6 +270,11 @@ dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "cache_2q"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "capnp"
@@ -2311,6 +2317,7 @@ dependencies = [
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
+"checksum cache_2q 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "888c7446c8037f61237cd399bf1a7dcbaebc2026ef208542f796f4db0d93497c"
 "checksum capnp 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c3b702741e96c00ab2240c49c74c5e3394dcc4e791acd6b0dfd0baa5c69a2b7"
 "checksum capnp 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2413f05bfed15863b5fd3c5b048d8efd324f6a0b2bc8c9e832de37446723a625"
 "checksum capnpc 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6003f6766260e621ff980048a777c6e594bf5c5062c6e76be83262e11b25ae87"

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,24 @@ debug:
 	$(CARGO) build --all
 	mkdir -p admintool/release/bin
 	cp -f .env admintool/
+	cp -f .env admintool/release
 	find target/debug -maxdepth 1 -perm -111 -type f -not \( -name "*-*" -prune \) -exec cp {} admintool/release/bin \;
 
 release:
 	$(CARGO) build --release --all
 	mkdir -p admintool/release/bin
 	cp -f .env admintool/
+	cp -f .env admintool/release
 	find target/release -maxdepth 1 -perm -111 -type f -not \( -name "*-*" -prune \) -exec cp {} admintool/release/bin \;
 
+setup-rust:
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2017-08-04
+	- . ~/.cargo/env;cargo install --force --vers 0.9.0 rustfmt;
+
+setup-solc:
+	add-apt-repository ppa:ethereum/ethereum
+	sudo apt-get update
+	sudo apt-get install solc
 
 setup1:
 	apt-get update -q
@@ -32,17 +42,15 @@ setup1:
 	apt-get install --allow-change-held-packages \
 		libsnappy-dev  capnproto  libgoogle-perftools-dev  libssl-dev libudev-dev  \
 		rabbitmq-server  google-perftools jq libsodium*
-	wget https://github.com/ethereum/solidity/releases/download/v0.4.15/solc-static-linux
-	mv solc-static-linux /usr/local/bin/solc
-	chmod +x /usr/local/bin/solc
-	/etc/init.d/rabbitmq-server restart
-	-rabbitmqctl add_vhost dev
-	-rabbitmqctl set_permissions -p dev guest ".*" ".*" ".*"
 
 setup2:
-	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2017-08-04
-	- . ~/.cargo/env;cargo install --force --vers 0.9.0 rustfmt;
 	pip install -r admintool/requirements.txt --user
+	/etc/init.d/rabbitmq-server restart
+	-rabbitmqctl stop_app
+	-rabbitmqctl reset
+	-rabbitmqctl start_app
+	-rabbitmqctl add_vhost dev
+	-rabbitmqctl set_permissions -p dev guest ".*" ".*" ".*"
 
 test:
 	$(CARGO) test --release --all --no-fail-fast 2>&1 |tee target/test.log

--- a/admintool/cita
+++ b/admintool/cita
@@ -12,7 +12,7 @@ function cita_setup() {
 
     node=node$1
     echo "setup ${node}"
-    echo "WARN: This command will clean date of this node!!!"
+    echo "WARN: This command will clean data of this node!!!"
 
     # rabbitmq
     sudo rabbitmqctl add_vhost ${node}

--- a/tests/integrate_test/cita_start.sh
+++ b/tests/integrate_test/cita_start.sh
@@ -10,7 +10,6 @@ if [ ! -n "$consensus" ]; then
 fi
 CUR_PATH=$(cd `dirname $0`; pwd)
 cd ${CUR_PATH}/../../admintool/
-./setup.sh
 ./admintool.sh -n $consensus
 
 setup_node() {


### PR DESCRIPTION
今天我们在部署云服务器的时候发现：

1. 部署错误了，需要重新部署，就需要注释掉
```
-	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2017-08-04		
-	- . ~/.cargo/env;cargo install --force --vers 0.9.0 rustfmt;
```
比较麻烦，所以移动到其他命令里了。

2. 需要重启rabbitmqctl

```
+	-rabbitmqctl stop_app
+	-rabbitmqctl reset
+	-rabbitmqctl start_app
```
否则会有一定概率出问题

3. 按照原来的setup按照的solc不能使用。

4. 需要拷贝.env 到release 目录下