### PR TITLE
reactor to support function return with output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,13 @@ debug:
 	$(CARGO) build --all
 	mkdir -p admintool/release/bin
 	cp -f .env admintool/release
-	find target/debug -maxdepth 1 -perm -111 -type f -not \( -name "*-*" -prune \) -exec cp {} admintool/release/bin \;
+	find target/debug -maxdepth 1 -perm -111 -type f -not \( -name "*-*" -prune \) -exec cp -f {} admintool/release/bin \;
 
 release:
 	$(CARGO) build --release --all
 	mkdir -p admintool/release/bin
 	cp -f .env admintool/release
-	find target/release -maxdepth 1 -perm -111 -type f -not \( -name "*-*" -prune \) -exec cp {} admintool/release/bin \;
+	find target/release -maxdepth 1 -perm -111 -type f -not \( -name "*-*" -prune \) -exec cp -f {} admintool/release/bin \;
 
 
 setup1:

--- a/chain/core/src/engines/mod.rs
+++ b/chain/core/src/engines/mod.rs
@@ -16,10 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 use builtin::Builtin;
-use native;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use util::{Address, U256, BytesRef};
-
 pub trait Engine: Sync + Send {
     /// The name of this engine.
     fn name(&self) -> &str;
@@ -44,26 +42,20 @@ pub trait Engine: Sync + Send {
     fn execute_builtin(&self, a: &Address, input: &[u8], output: &mut BytesRef) {
         self.builtins().get(a).expect("attempted to execute nonexistent builtin").execute(input, output);
     }
-    fn register(&mut self, addr: Address, contract: Box<native::Contract>);
-    fn unregister(&mut self, addr: Address) -> Option<Box<native::Contract>>;
-    fn get_native_contract(&self, addr: &Address) -> Option<&Box<native::Contract>>;
+    // fn register(&mut self, addr: Address, contract: Box<native::Contract>);
+    // fn unregister(&mut self, addr: Address) -> Option<Box<native::Contract>>;
+    // fn get_native_contract(&self, addr: &Address) -> Option<&Box<native::Contract>>;
 }
 
 /// An engine which does not provide any consensus mechanism and does not seal blocks.
 pub struct NullEngine {
     builtins: BTreeMap<Address, Builtin>,
-    contracts: HashMap<Address, Box<native::Contract>>,
 }
 
 impl NullEngine {
     /// Returns new instance of NullEngine with default VM Factory
     pub fn new(builtins: BTreeMap<Address, Builtin>) -> Self {
-        let mut engine = NullEngine {
-            builtins: builtins,
-            contracts: HashMap::new(),
-        };
-        engine.register(Address::from(0x400), Box::new(native::NowPay::new()));
-        engine
+        NullEngine { builtins: builtins }
     }
 }
 
@@ -80,17 +72,5 @@ impl Engine for NullEngine {
 
     fn builtins(&self) -> &BTreeMap<Address, Builtin> {
         &self.builtins
-    }
-
-    fn register(&mut self, addr: Address, contract: Box<native::Contract>) {
-        self.contracts.insert(addr, contract);
-    }
-
-    fn unregister(&mut self, addr: Address) -> Option<Box<native::Contract>> {
-        self.contracts.remove(&addr)
-    }
-
-    fn get_native_contract(&self, addr: &Address) -> Option<&Box<native::Contract>> {
-        self.contracts.get(addr)
     }
 }

--- a/chain/core/src/externalities.rs
+++ b/chain/core/src/externalities.rs
@@ -25,6 +25,7 @@ use env_info::EnvInfo;
 use evm::{self, MessageCallResult, Schedule, Factory};
 use executed::CallType;
 use executive::*;
+use native::Factory as NativeFactory;
 use state::State;
 use state::backend::Backend as StateBackend;
 use std::cmp;
@@ -32,7 +33,6 @@ use std::sync::Arc;
 use substate::Substate;
 use trace::{Tracer, VMTracer};
 use util::*;
-
 /// Policy for handling output data on `RETURN` opcode.
 pub enum OutputPolicy<'a, 'b> {
     /// Return reference to fixed sized output.
@@ -76,6 +76,7 @@ where
     env_info: &'a EnvInfo,
     engine: &'a Engine,
     vm_factory: &'a Factory,
+    native_factory: &'a NativeFactory,
     depth: usize,
     origin_info: OriginInfo,
     substate: &'a mut Substate,
@@ -94,12 +95,13 @@ where
 {
     /// Basic `Externalities` constructor.
     #[cfg_attr(feature = "dev", allow(too_many_arguments))]
-    pub fn new(state: &'a mut State<B>, env_info: &'a EnvInfo, engine: &'a Engine, vm_factory: &'a Factory, depth: usize, origin_info: OriginInfo, substate: &'a mut Substate, output: OutputPolicy<'a, 'a>, tracer: &'a mut T, vm_tracer: &'a mut V) -> Self {
+    pub fn new(state: &'a mut State<B>, env_info: &'a EnvInfo, engine: &'a Engine, vm_factory: &'a Factory, native_factory: &'a NativeFactory, depth: usize, origin_info: OriginInfo, substate: &'a mut Substate, output: OutputPolicy<'a, 'a>, tracer: &'a mut T, vm_tracer: &'a mut V) -> Self {
         Externalities {
             state: state,
             env_info: env_info,
             engine: engine,
             vm_factory: vm_factory,
+            native_factory: native_factory,
             depth: depth,
             origin_info: origin_info,
             substate: substate,
@@ -189,7 +191,7 @@ where
             debug!(target: "ext", "Database corruption encountered: {:?}", e);
             return evm::ContractCreateResult::Failed;
         }
-        let mut ex = Executive::from_parent(self.state, self.env_info, self.engine, self.vm_factory, self.depth);
+        let mut ex = Executive::from_parent(self.state, self.env_info, self.engine, self.vm_factory, self.native_factory, self.depth);
 
         // TODO: handle internal error separately
         match ex.create(params, self.substate, self.tracer, self.vm_tracer) {
@@ -231,7 +233,7 @@ where
             params.value = ActionValue::Transfer(value);
         }
 
-        let mut ex = Executive::from_parent(self.state, self.env_info, self.engine, self.vm_factory, self.depth);
+        let mut ex = Executive::from_parent(self.state, self.env_info, self.engine, self.vm_factory, self.native_factory, self.depth);
 
         match ex.call(params, self.substate, BytesRef::Fixed(output), self.tracer, self.vm_tracer) {
             Ok(gas_left) => MessageCallResult::Success(gas_left),

--- a/chain/core/src/factory.rs
+++ b/chain/core/src/factory.rs
@@ -17,6 +17,7 @@
 
 use account_db::Factory as AccountFactory;
 use evm::Factory as EvmFactory;
+use native::Factory as NativeFactory;
 use util::trie::TrieFactory;
 
 /// Collection of factories.
@@ -24,6 +25,7 @@ use util::trie::TrieFactory;
 pub struct Factories {
     /// factory for evm.
     pub vm: EvmFactory,
+    pub native: NativeFactory,
     /// factory for tries.
     pub trie: TrieFactory,
     /// factory for account databases.

--- a/chain/core/src/libchain/block.rs
+++ b/chain/core/src/libchain/block.rs
@@ -317,7 +317,6 @@ impl OpenBlock {
     pub fn apply_transaction(&mut self, t: &SignedTransaction) {
         let env_info = self.env_info();
         let has_traces = self.traces.is_some();
-        info!("env_info says gas_used={}", env_info.gas_used);
         match self.state.apply(&env_info, &t, has_traces) {
             Ok(outcome) => {
                 let trace = outcome.trace;

--- a/chain/core/src/libchain/chain.rs
+++ b/chain/core/src/libchain/chain.rs
@@ -40,6 +40,7 @@ use libchain::genesis::Genesis;
 pub use libchain::transaction::*;
 use libproto::blockchain::{ProofType, Status as ProtoStatus};
 use libproto::request::FullTransaction;
+use native::Factory as NativeFactory;
 use proof::TendermintProof;
 use receipt::{Receipt, LocalizedReceipt};
 use state::State;
@@ -188,6 +189,7 @@ impl Chain {
         let trie_factory = TrieFactory::new(TrieSpec::Generic);
         let factories = Factories {
             vm: EvmFactory::default(),
+            native: NativeFactory::default(),
             trie: trie_factory,
             accountdb: Default::default(),
         };
@@ -753,7 +755,8 @@ impl Chain {
             vm_tracing: analytics.vm_tracing,
             check_nonce: false,
         };
-        let ret = Executive::new(&mut state, &env_info, &engine, &self.factories.vm).transact(t, options)?;
+        let ret = Executive::new(&mut state, &env_info, &engine, &self.factories.vm, &self.factories.native)
+            .transact(t, options)?;
 
         Ok(ret)
     }

--- a/chain/core/src/native/mod.rs
+++ b/chain/core/src/native/mod.rs
@@ -15,64 +15,132 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-////////////////////////////////////////////////////////////////////////////////
-
-
-////////////////////////////////////////////////////////////////////////////////
-
 use action_params::ActionParams;
 use evm::{self, Ext, GasLeft};
 use std::collections::HashMap;
-use util::{H256, U256};
+use util::Address;
 
 ////////////////////////////////////////////////////////////////////////////////
-pub type Signature = u32;
-pub type Function = Fn(&ActionParams, &mut Ext) -> evm::Result<GasLeft<'static>> + Sync + Send;
 pub mod storage;
+pub type Signature = u32;
+
 ////////////////////////////////////////////////////////////////////////////////
+pub trait ContractClone {
+    fn clone_box(&self) -> Box<Contract>;
+}
+
+impl<T> ContractClone for T
+where
+    T: 'static + Contract + Clone,
+{
+    fn clone_box(&self) -> Box<Contract> {
+        Box::new(self.clone())
+    }
+}
+
+// We can now implement Clone manually by forwarding to clone_box.
+impl Clone for Box<Contract> {
+    fn clone(&self) -> Box<Contract> {
+        self.clone_box()
+    }
+}
+
 // Contract
-pub trait Contract: Sync + Send {
-    fn get_function(&self, hash: &Signature) -> Option<&Box<Function>>;
-    fn exec(&self, params: &ActionParams, ext: &mut Ext) {
-        if let Some(data) = params.clone().data.unwrap().get(0..4) {
-            let signature = data.iter().fold(0u32, |acc, &x| (acc << 8) + (x as u32));
-            if let Some(exec_call) = self.get_function(&signature) {
-                //let cost = self.engine.cost_of_builtin(&params.code_address, data);
-                let cost = U256::from(100);
-                if cost <= params.gas {
-                    let _ = exec_call(params, ext);
-                    //self.state.discard_checkpoint();
-                    return;
-                }
-            }
-        }
-    }
+pub trait Contract: Sync + Send + ContractClone {
+    fn exec(&mut self, params: ActionParams, ext: &mut Ext) -> Result<GasLeft, evm::Error>;
+    fn create(&self) -> Box<Contract>;
 }
+
 
 ////////////////////////////////////////////////////////////////////////////////
-// NowPay
-pub struct NowPay {
-    functions: HashMap<Signature, Box<Function>>,
+#[derive(Clone)]
+pub struct Factory {
+    contracts: HashMap<Address, Box<Contract>>,
 }
 
-impl Contract for NowPay {
-    fn get_function(&self, hash: &Signature) -> Option<&Box<Function>> {
-        self.functions.get(hash)
+
+impl Factory {
+    pub fn new_contract(&self, address: Address) -> Option<Box<Contract>> {
+        if let Some(contract) = self.contracts.get(&address) { Some(contract.create()) } else { None }
+    }
+    pub fn register(&mut self, address: Address, contract: Box<Contract>) {
+        self.contracts.insert(address, contract);
+    }
+    pub fn unregister(&mut self, address: Address) {
+        self.contracts.remove(&address);
     }
 }
 
-impl NowPay {
-    pub fn new() -> Self {
-        let mut contract = NowPay { functions: HashMap::<Signature, Box<Function>>::new() };
-        contract.functions.insert(0, Box::new(NowPay::set_value));
-        contract
+impl Default for Factory {
+    fn default() -> Self {
+        let factory = Factory { contracts: HashMap::new() };
+        // here we register contracts with addresses defined in genesis.json.
+        factory
     }
-    pub fn set_value(params: &ActionParams, ext: &mut Ext) -> evm::Result<GasLeft<'static>> {
-        if let Some(ref data) = params.data {
-            if let Some(data) = data.get(4..32) {
-                let _ = ext.set_storage(H256::from(0), H256::from(data));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::storage::{Scalar, Array, Map};
+    use byteorder::{BigEndian, ByteOrder};
+    use evm::tests::FakeExt;
+    use util::{H256, U256, Address};
+
+    ////////////////////////////////////////////////////////////////////////////////
+    // NowPay
+    #[derive(Clone)]
+    pub struct NowPay {
+        output: Vec<u8>,
+        scalar_string: Scalar,
+        array_u256: Array,
+        map_u256: Map,
+    }
+
+    impl Contract for NowPay {
+        fn exec(&mut self, params: ActionParams, ext: &mut Ext) -> Result<GasLeft, evm::Error> {
+            let signature = BigEndian::read_u32(params.clone().data.unwrap().get(0..4).unwrap());
+            match signature {
+                0 => self.init(params, ext),
+                1 => self.get(params, ext),
+                _ => Err(evm::Error::OutOfGas),
             }
         }
-        Ok(GasLeft::Known(U256::from(0)))
+        fn create(&self) -> Box<Contract> {
+            Box::new(NowPay::default())
+        }
+    }
+
+    impl Default for NowPay {
+        fn default() -> Self {
+            NowPay {
+                output: Vec::new(),
+                scalar_string: Scalar::new(H256::from(0)),
+                array_u256: Array::new(H256::from(1)),
+                map_u256: Map::new(H256::from(2)),
+            }
+        }
+    }
+    impl NowPay {
+        fn get(&mut self, _params: ActionParams, _ext: &mut Ext) -> Result<GasLeft, evm::Error> {
+            self.output.push(8);
+            Ok(GasLeft::NeedsReturn(U256::from(100), self.output.as_slice()))
+        }
+        fn init(&mut self, _params: ActionParams, _ext: &mut Ext) -> Result<GasLeft, evm::Error> {
+            Ok(GasLeft::Known(U256::from(100)))
+        }
+    }
+
+    #[test]
+    fn test_native_contract() {
+        let mut factory = Factory::default();
+        factory.register(Address::from(0), Box::new(NowPay::default()));
+
+        let mut params = ActionParams::default();
+        let input = vec![0, 0, 0, 1, 1, 2, 3, 4];
+        params.data = Some(input);
+        let mut ext = FakeExt::new();
+        let mut contract = factory.new_contract(Address::from(0)).unwrap();
+        let _ = contract.exec(params, &mut ext).unwrap();
     }
 }

--- a/chain/core/src/state/mod.rs
+++ b/chain/core/src/state/mod.rs
@@ -486,7 +486,8 @@ impl<B: Backend> State<B> {
             check_nonce: false,
         };
         let vm_factory = self.factories.vm.clone();
-        let e = Executive::new(self, env_info, engine, &vm_factory).transact(t, options)?;
+        let native_factory = self.factories.native.clone();
+        let e = Executive::new(self, env_info, engine, &vm_factory, &native_factory).transact(t, options)?;
 
         // TODO uncomment once to_pod() works correctly.
         //        trace!("Applied transaction. Diff:\n{}\n", state_diff::diff_pod(&old, &self.to_pod()));


### PR DESCRIPTION
原生合约的接口(storage/parameter/init)与solidity合约相同:  
1) storage已经提供工具封装  
2) parameter的编码量比较简单, 暂不封装  
3) 原生合约编写的系统合约的初始化采用genesis.json, 与solidity编写的系统合约一致 

原生合约开发流程:  
1) 根据native::Contract编写rust代码  
2) 在native::Factory里面注册该合约  
3) 编写工具程序输出合约构造生成的storage  
4) 在genesis.json的alloc中申请account的nonce/storage  

完整的原生合约开发文档, 另外开issue整理. 