### PR TITLE
Add vagrant support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,8 @@ logfile
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock
 
 # vagrant file
-Vagrantfile
 .vagrant
+ubuntu-*-console.log
 
 # transaction tool output
 admintool/txtool/output/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,7 @@ dependencies = [
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1550,8 +1551,7 @@ dependencies = [
  "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka-sys 0.11.0-0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdkafka 0.12.0 (git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062)",
  "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1657,23 +1657,22 @@ dependencies = [
 [[package]]
 name = "rdkafka"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062#84d40623f38455dc7c3aa09539319a4d81bc57ab"
 dependencies = [
- "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "errno 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rdkafka-sys 0.11.0-0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdkafka-sys 0.11.0-1 (git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062)",
+ "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rdkafka-sys"
-version = "0.11.0-0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.11.0-1"
+source = "git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062#84d40623f38455dc7c3aa09539319a4d81bc57ab"
 dependencies = [
  "libz-sys 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "lz4-sys 1.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2566,8 +2565,8 @@ dependencies = [
 "checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
 "checksum rayon 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b614fe08b6665cb9a231d07ac1364b0ef3cb3698f1239ee0c4c3a88a524f54c8"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
-"checksum rdkafka 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4569d6088919c4b6de9b2dcdd8b3c769d6c46fac9baa8cdeea7266aa7c9ccfe8"
-"checksum rdkafka-sys 0.11.0-0 (registry+https://github.com/rust-lang/crates.io-index)" = "82fdf77c58f05e9d512f963da3b7e3f035d5d3db2ae2fa6dc6383d12806e7121"
+"checksum rdkafka 0.12.0 (git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062)" = "<none>"
+"checksum rdkafka-sys 0.11.0-1 (git+https://github.com/fede1024/rust-rdkafka.git?rev=84d4062)" = "<none>"
 "checksum redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02a92e223490cc63d9230c4cdf132a48ce154ab1e063558e3841e219c2ea3f91"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$set_environment_variables = <<SCRIPT
+tee "/etc/profile.d/cita_boot.sh" > "/dev/null" <<EOF
+export USING_VAGRANT=1
+export VAGRANT_DATA_PATH=/home/ubuntu/citadata
+EOF
+SCRIPT
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "cryptape/easy_cita"
+  config.vm.box_version = "0.0.1"
+  
+  config.ssh.shell = "bash -c 'BASH_ENV=/etc/profile exec bash'"
+
+  config.vm.provider "virtualbox" do |v|
+        v.memory = 4096
+        v.cpus = 4
+  end
+
+  config.vm.provision "shell", inline: $set_environment_variables, run: "always"
+end

--- a/admintool/admintool.sh
+++ b/admintool/admintool.sh
@@ -118,15 +118,15 @@ if [ ! -n "$TX_POOL_SIZE" ]; then
     TX_POOL_SIZE=0
 fi
 
-DATA_PATH=`pwd`/release
-CREATE_KEY_ADDR_PATH=$DATA_PATH/bin/create_key_addr
+RELEASE_PATH=`pwd`/release
+CREATE_KEY_ADDR_PATH=$RELEASE_PATH/bin/create_key_addr
 
-if [ ! -f "$DATA_PATH" ]; then
-    mkdir -p $DATA_PATH
+if [ ! -f "$RELEASE_PATH" ]; then
+    mkdir -p $RELEASE_PATH
 fi
 
-if [ -f "$DATA_PATH/authorities" ]; then
-    rm $DATA_PATH/authorities
+if [ -f "$RELEASE_PATH/authorities" ]; then
+    rm $RELEASE_PATH/authorities
 fi
 
 if [ -f "genesis.json" ]; then
@@ -136,49 +136,49 @@ fi
 echo "Step 1: ********************************************************"
 for ((ID=0;ID<$SIZE;ID++))
 do
-    mkdir -p $DATA_PATH/node$ID
+    mkdir -p $RELEASE_PATH/node$ID
     echo "Start generating private Key for Node" $ID "!"
-    python create_keys_addr.py $DATA_PATH $ID $CREATE_KEY_ADDR_PATH
-    echo "[PrivateKey Path] : " $DATA_PATH/node$ID
+    python create_keys_addr.py $RELEASE_PATH $ID $CREATE_KEY_ADDR_PATH
+    echo "[PrivateKey Path] : " $RELEASE_PATH/node$ID
     echo "End generating private Key for Node" $ID "!"
     echo "Start creating Network Node" $ID "Configuration!"
-    python create_network_config.py $DATA_PATH $ID $SIZE $IP_LIST
+    python create_network_config.py $RELEASE_PATH $ID $SIZE $IP_LIST
     echo "End creating Network Node" $ID "Configuration!"
     echo "########################################################"
 done
 echo "Step 2: ********************************************************"
 
-python create_genesis.py --authorities "$DATA_PATH/authorities"
+python create_genesis.py --authorities "$RELEASE_PATH/authorities"
 for ((ID=0;ID<$SIZE;ID++))
 do
     echo "Start creating Node " $ID " Configuration!"
-    python create_node_config.py $DATA_PATH $CONSENSUS_NAME $ID $DURATION $IS_TEST $BLOCK_TX_LIMIT $TX_FILTER_SIZE $TX_POOL_SIZE
+    python create_node_config.py $RELEASE_PATH $CONSENSUS_NAME $ID $DURATION $IS_TEST $BLOCK_TX_LIMIT $TX_FILTER_SIZE $TX_POOL_SIZE
     echo "End creating Node " $ID "Configuration!"
-    cp genesis.json $DATA_PATH/node$ID/genesis.json
+    cp genesis.json $RELEASE_PATH/node$ID/genesis.json
 done
 
 echo "Step 3: ********************************************************"
 for ((ID=0;ID<$SIZE;ID++))
 do
     echo "Start creating Node " $ID " env!"
-    cp cita $DATA_PATH/node$ID/
-    cp $DATA_PATH/.env $DATA_PATH/node$ID/
+    cp cita $RELEASE_PATH/node$ID/
+    cp $RELEASE_PATH/.env $RELEASE_PATH/node$ID/
     case "$OSTYPE" in
         darwin*)  
-            sed -ig "s/dev/node$ID/g" $DATA_PATH/node$ID/.env
-            sed -ig "s/tendermint/$CONSENSUS_NAME/g" $DATA_PATH/node$ID/cita
+            sed -ig "s/dev/node$ID/g" $RELEASE_PATH/node$ID/.env
+            sed -ig "s/tendermint/$CONSENSUS_NAME/g" $RELEASE_PATH/node$ID/cita
             ;; 
         *)       
-            sed -i "s/dev/node$ID/g" $DATA_PATH/node$ID/.env
-            sed -i "s/tendermint/$CONSENSUS_NAME/g" $DATA_PATH/node$ID/cita
+            sed -i "s/dev/node$ID/g" $RELEASE_PATH/node$ID/.env
+            sed -i "s/tendermint/$CONSENSUS_NAME/g" $RELEASE_PATH/node$ID/cita
             ;;
     esac
     echo "Start copy binary for Node " $ID "!"
     if [ -n "$DEV_MOD" ]; then
-        rm -f $DATA_PATH/node$ID/bin
-        ln -s $DATA_PATH/bin $DATA_PATH/node$ID/bin
+        rm -f $RELEASE_PATH/node$ID/bin
+        ln -s $RELEASE_PATH/bin $RELEASE_PATH/node$ID/bin
     else
-        cp -rf $DATA_PATH/bin $DATA_PATH/node$ID/
+        cp -rf $RELEASE_PATH/bin $RELEASE_PATH/node$ID/
     fi
 done
 
@@ -217,7 +217,7 @@ fi
 
 for ((ID=0;ID<$SIZE;ID++))
 do
-    mkdir -p $DATA_PATH/node$ID
+    mkdir -p $RELEASE_PATH/node$ID
     if [ -n "$DEV_MOD" ]; then
         ((H_PORT=$HTTP_PORT+$ID))
         ((W_PORT=$WS_PORT+$ID))
@@ -226,10 +226,10 @@ do
         W_PORT=$WS_PORT
     fi
     echo "Start generating JsonRpc Configuration Node" $ID "!"
-    python create_jsonrpc_config.py $HTTP_ENABLE $H_PORT $WS_ENABLE $W_PORT $DATA_PATH
-    echo "[JsonRpc Configuration Path] : " $DATA_PATH/node$ID
+    python create_jsonrpc_config.py $HTTP_ENABLE $H_PORT $WS_ENABLE $W_PORT $RELEASE_PATH
+    echo "[JsonRpc Configuration Path] : " $RELEASE_PATH/node$ID
     echo "JsonRpc Configuration for Node" $ID "!"
-    cp $DATA_PATH/jsonrpc.json $DATA_PATH/node$ID/
+    cp $RELEASE_PATH/jsonrpc.json $RELEASE_PATH/node$ID/
 
     echo "########################################################"
 done

--- a/admintool/cita
+++ b/admintool/cita
@@ -20,7 +20,11 @@ function cita_setup() {
     sudo rabbitmqctl list_permissions -p ${node}
 
     # clean up database and local data
-    rm -rf ./data
+    data_path=${VAGRANT_DATA_PATH:-"./data"}
+    echo "Will remove data_path is ${data_path}"
+    cwd=$(pwd)
+    echo "current dir is ${cwd}"
+    rm -rf ${data_path}
 }
 
 function cita_start() {

--- a/chain/main.rs
+++ b/chain/main.rs
@@ -44,16 +44,15 @@ use forward::*;
 use log::LogLevelFilter;
 use protobuf::Message;
 use pubsub::start_pubsub;
-use std::env;
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 use std::thread;
 use std::time;
 use std::time::Duration;
 use synchronizer::Synchronizer;
+use util::datapath::DataPath;
 use util::kvdb::{Database, DatabaseConfig};
 
-pub const DATA_PATH: &'static str = "DATA_PATH";
 
 fn main() {
     dotenv::dotenv().ok();
@@ -84,7 +83,9 @@ fn main() {
                       let (key, msg) = crx_sub.recv().unwrap();
                       forward::chain_pool(&pool, &tx, key_to_id(&key), msg);
                   });
-    let nosql_path = env::var(DATA_PATH).expect(format!("{} must be set", DATA_PATH).as_str()) + "/nosql";
+
+    let nosql_path = DataPath::nosql_path();
+    trace!("nosql_path is {:?}", nosql_path);
     let config = DatabaseConfig::with_columns(db::NUM_COLUMNS);
     let db = Database::open(&config, &nosql_path).unwrap();
     let genesis = Genesis::init(config_path);

--- a/consensus/proof/src/tendermint_proof.rs
+++ b/consensus/proof/src/tendermint_proof.rs
@@ -19,14 +19,13 @@ use bincode::{serialize, deserialize, Infinite};
 use crypto::{Signature, Sign, pubkey_to_address};
 use libproto::blockchain::{Proof, ProofType};
 use std::collections::HashMap;
-use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use std::usize::MAX;
 use util::{H256, Address};
 use util::Hashable;
+use util::datapath::DataPath;
 
-pub const DATA_PATH: &'static str = "DATA_PATH";
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash)]
 pub enum Step {
     Propose,
@@ -63,7 +62,7 @@ impl TendermintProof {
     }
 
     pub fn store(&self) {
-        let proof_path = env::var(DATA_PATH).expect(format!("{} must be set", DATA_PATH).as_str()) + "/proof.bin";
+        let proof_path = DataPath::proof_bin_path();
         let mut file = File::create(&proof_path).unwrap();
         let encoded_proof: Vec<u8> = serialize(&self, Infinite).unwrap();
         file.write_all(&encoded_proof).unwrap();
@@ -71,8 +70,8 @@ impl TendermintProof {
     }
 
     pub fn load(&mut self) {
-        let data_path = env::var(DATA_PATH).expect(format!("{} must be set", DATA_PATH).as_str());
-        if let Ok(mut file) = File::open(&(data_path + "/proof.bin")) {
+        let proof_path = DataPath::proof_bin_path();
+        if let Ok(mut file) = File::open(&proof_path) {
             let mut content = Vec::new();
             if file.read_to_end(&mut content).is_ok() {
                 if let Ok(decoded) = deserialize(&content[..]) {

--- a/consensus/tdmint/src/core/tendermint.rs
+++ b/consensus/tdmint/src/core/tendermint.rs
@@ -37,6 +37,7 @@ use std::sync::Arc;
 use std::sync::mpsc::{Sender, Receiver, RecvError};
 use std::time::Instant;
 use util::{H256, Address, Hashable};
+use util::datapath::DataPath;
 
 const INIT_HEIGHT: usize = 1;
 const INIT_ROUND: usize = 0;
@@ -53,7 +54,6 @@ const ID_NEW_PROPOSAL: u32 = (submodules::CONSENSUS << 16) + topics::NEW_PROPOSA
 
 const TIMEOUT_RETRANSE_MULTIPLE: u32 = 5;
 const TIMEOUT_LOW_ROUND_MESSAGE_MULTIPLE: u32 = 10;
-const DATA_PATH: &'static str = "DATA_PATH";
 
 pub type TransType = (u32, u32, MsgClass);
 pub type PubType = (String, Vec<u8>);
@@ -133,7 +133,8 @@ impl TenderMint {
         if params.is_test {
             trace!("Run for test!");
         }
-        let logpath = ::std::env::var(DATA_PATH).expect(format!("{} must be set", DATA_PATH).as_str()) + "/wal";
+
+        let logpath = DataPath::wal_path();
 
         trace!("tx pool size {}", params.tx_pool_size);
         TenderMint {

--- a/consensus/tdmint/src/core/txwal.rs
+++ b/consensus/tdmint/src/core/txwal.rs
@@ -18,9 +18,9 @@
 use chain_core::db;
 use libproto::blockchain::SignedTransaction;
 use protobuf::core::{Message, parse_from_bytes};
-use std::env;
 use std::sync::Arc;
 use tx_pool::Pool;
+use util::datapath::DataPath;
 use util::kvdb::{DatabaseConfig, Database, KeyValueDB};
 
 #[derive(Clone)]
@@ -31,7 +31,7 @@ pub struct Txwal {
 impl Txwal {
     pub fn new(path: &str) -> Self {
 
-        let nosql_path = env::var("DATA_PATH").expect(format!("{} must be set", "DATA_PATH").as_str()) + path;
+        let nosql_path = DataPath::root_node_path() + path;
         let config = DatabaseConfig::with_columns(db::NUM_COLUMNS);
         let db = Database::open(&config, &nosql_path).unwrap();
         Txwal { db: Arc::new(db) }

--- a/share_libs/pubsub_kafka/Cargo.toml
+++ b/share_libs/pubsub_kafka/Cargo.toml
@@ -3,9 +3,11 @@ name = "pubsub_kafka"
 version = "0.1.0"
 authors = ["lycbitbucket <liuyucheng@cryptape.com>"]
 
+[dependencies.rdkafka]
+git = "https://github.com/fede1024/rust-rdkafka.git"
+rev = "84d4062"
+
 [dependencies]
-rdkafka = "^0.12.0"
-rdkafka-sys="0.11.0-0"
 errno = "^0.1.8"
 futures = "^0.1.13"
 libc = "^0.2.0"

--- a/share_libs/pubsub_kafka/src/lib.rs
+++ b/share_libs/pubsub_kafka/src/lib.rs
@@ -3,7 +3,6 @@ extern crate log;
 extern crate clap;
 extern crate futures;
 extern crate rdkafka;
-extern crate rdkafka_sys;
 
 use futures::*;
 
@@ -14,6 +13,7 @@ use rdkafka::consumer::{Consumer, ConsumerContext, CommitMode, Rebalance};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::error::KafkaResult;
 use rdkafka::producer::FutureProducer;
+use rdkafka::types;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::Sender;
 use std::thread;
@@ -34,7 +34,7 @@ impl ConsumerContext for ConsumerContextExample {
         trace!("Post rebalance {:?}", rebalance);
     }
 
-    fn commit_callback(&self, _result: KafkaResult<()>, _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList) {
+    fn commit_callback(&self, _result: KafkaResult<()>, _offsets: *mut types::RDKafkaTopicPartitionList) {
         trace!("Committing offsets");
     }
 }

--- a/share_libs/util/Cargo.toml
+++ b/share_libs/util/Cargo.toml
@@ -30,6 +30,7 @@ ethcore-bloom-journal = { path = "../bloom" }
 regex = "0.2"
 lru-cache = "0.1.0"
 ethcore-logger = { path = "../logger" }
+uuid = "0.4"
 
 [features]
 default = ["sha3hash"]

--- a/share_libs/util/src/datapath.rs
+++ b/share_libs/util/src/datapath.rs
@@ -1,0 +1,100 @@
+// CITA
+// Copyright 2016-2017 Cryptape Technologies LLC.
+
+// This program is free software: you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any
+// later version.
+
+// This program is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied
+// warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+// PURPOSE. See the GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! wrapper leveldb, rocketsdb data path.
+//! Fix "Open Error: IO error Invalid argument" when using vagrant.
+//! More about above error. See <https://github.com/Level/levelup/issues/222>.
+
+use std::env;
+use uuid::Uuid;
+
+pub const DATA_PATH: &'static str = "DATA_PATH";
+const VAGRANT_DATA_PATH: &'static str = "VAGRANT_DATA_PATH";
+
+pub struct DataPath;
+
+impl DataPath {
+    /// root data path
+    fn root_data_path() -> String {
+        let is_using_vagrant = DataPath::is_using_vagrant();
+        let data_path = if is_using_vagrant {
+            env::var(VAGRANT_DATA_PATH).expect(format!("{} must be set", DATA_PATH).as_str())
+        } else {
+            env::var(DATA_PATH).expect(format!("{} must be set", DATA_PATH).as_str())
+        };
+
+        return data_path;
+    }
+
+
+    /// nosql path
+    pub fn nosql_path() -> String {
+        let data_path = DataPath::root_node_path();
+
+        return data_path + "/nosql";
+    }
+
+    /// proof.bin path
+    pub fn proof_bin_path() -> String {
+        let data_path = DataPath::root_node_path();
+
+        return data_path + "/proof.bin";
+    }
+
+    /// wal log path
+    pub fn wal_path() -> String {
+        let data_path = DataPath::root_node_path();
+
+        return data_path + "/wal";
+    }
+
+    /// node path
+    pub fn root_node_path() -> String {
+        let node_component = match env::current_dir() {
+            Ok(pathbuf) => {
+                let filename = pathbuf.file_name();
+                let path = match filename {
+                    Some(name) => String::from(name.to_str().unwrap()),
+                    None => Uuid::new_v4().simple().to_string(),
+                };
+                path
+            }
+            Err(_) => {
+                Uuid::new_v4().simple().to_string()
+            }
+        };
+
+        let is_using_vagrant = DataPath::is_using_vagrant();
+        let node_path = if is_using_vagrant {
+            DataPath::root_data_path() + "/" + &node_component
+        } else {
+            DataPath::root_data_path()
+        };
+
+        String::from(node_path)
+    }
+}
+
+trait VagrantHelper {
+    fn is_using_vagrant() -> bool;
+}
+
+impl VagrantHelper for DataPath {
+    fn is_using_vagrant() -> bool {
+        env::var("USING_VAGRANT").unwrap_or("0".to_string()) == "1"
+    }
+}

--- a/share_libs/util/src/lib.rs
+++ b/share_libs/util/src/lib.rs
@@ -37,6 +37,7 @@ extern crate blake2b;
 
 #[macro_use]
 extern crate log as rlog;
+extern crate uuid;
 
 pub mod avl;
 pub mod merklehash;
@@ -59,11 +60,13 @@ pub mod semantic_version;
 pub mod snappy;
 pub mod cache;
 pub mod crypto;
+pub mod datapath;
 
 
 pub use ansi_term::{Colour, Style};
 pub use bigint::*;
 pub use bytes::*;
+pub use datapath::*;
 // pub use timer::*;
 pub use error::*;
 pub use hashable::*;

--- a/tests/chain_performance/src/main.rs
+++ b/tests/chain_performance/src/main.rs
@@ -44,13 +44,13 @@ use core::libchain::Genesis;
 use cpuprofiler::PROFILER;
 use generate_block::Generateblock;
 use log::LogLevelFilter;
-use std::{env, time, thread};
+use std::{time, thread};
 use std::sync::Arc;
 use std::sync::mpsc::channel;
 use util::H256;
+use util::datapath::DataPath;
 use util::kvdb::{Database, DatabaseConfig};
 
-pub const DATA_PATH: &'static str = "DATA_PATH";
 
 //创建合约交易性能
 fn create_contract(block_tx_num: i32, call: Callchain, pre_hash: H256, flag_prof_start: u64, flag_prof_duration: u64, flag: i32) {
@@ -166,7 +166,7 @@ fn main() {
     let flag_prof_duration = matches.value_of("flag_prof_duration").unwrap_or("0").parse::<u64>().unwrap();
 
     //数据库配置
-    let nosql_path = env::var(DATA_PATH).expect(format!("{} must be set", DATA_PATH).as_str()) + "/nosql";
+    let nosql_path = DataPath::nosql_path();
     let config = DatabaseConfig::with_columns(db::NUM_COLUMNS);
     let db = Database::open(&config, &nosql_path).unwrap();
     let genesis = Genesis::init(config_path);


### PR DESCRIPTION
支持vagrant做了如下修改：
1. vagrant里rdkafka-sys编译会报错"/usr/bin/ld:librdkafka.lds:1: syntax error in VERSION script"
对pubsub_kafka模块做了修改 @programmer-liu 帮忙review这部分代码。[参考rdkafka的issue讨论](https://github.com/fede1024/rust-rdkafka/issues/57)
2. vagrant里使用rocketsdb会报错Open Error: IO error Invalid argument，这个是vagrant和vboxsf的bug。为了绕过这个问题，我让release目录下node0,node1,node2,node3直接创建在guest机器上。
由于修改了目录的配置 可能影响共识 chain两个模块。所以, @u2  @jerry-yu 帮忙review下。
3. windows下 @jerry-yu 帮忙测试下  [参考文档](https://www.sitepoint.com/getting-started-vagrant-windows/)
