### PR TITLE
Update cita-common and bft for add `from` to `body` of `getBlockByNumber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,7 +87,7 @@ dependencies = [
 [[package]]
 name = "authority_manage"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -215,7 +215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "blake2b"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -427,7 +427,7 @@ dependencies = [
 [[package]]
 name = "cita-crypto"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-ed25519 0.6.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -438,7 +438,7 @@ dependencies = [
 [[package]]
 name = "cita-crypto-trait"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
 ]
@@ -446,7 +446,7 @@ dependencies = [
 [[package]]
 name = "cita-directories"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -454,7 +454,7 @@ dependencies = [
 [[package]]
 name = "cita-ed25519"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -548,7 +548,7 @@ dependencies = [
 [[package]]
 name = "cita-merklehash"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "hashable 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "cita-secp256k1"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -621,7 +621,7 @@ dependencies = [
 [[package]]
 name = "cita-sm2"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -635,7 +635,7 @@ dependencies = [
 [[package]]
 name = "cita-types"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plain_hasher 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -985,7 +985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "db"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "elastic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "engine"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1089,7 +1089,7 @@ dependencies = [
 [[package]]
 name = "error"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 
 [[package]]
 name = "error-chain"
@@ -1150,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "ethcore-bloom-journal"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "siphasher 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1388,7 +1388,7 @@ dependencies = [
 [[package]]
 name = "hashable"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "blake2b 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1565,7 +1565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "jsonrpc-proto"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1582,7 +1582,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-types"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1596,7 +1596,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-types-internals"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "libproto"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-merklehash 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2211,7 +2211,7 @@ dependencies = [
 [[package]]
 name = "panic_hook"
 version = "0.0.1"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2338,7 +2338,7 @@ dependencies = [
 [[package]]
 name = "pubsub"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pubsub_kafka 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "pubsub_kafka"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2360,7 +2360,7 @@ dependencies = [
 [[package]]
 name = "pubsub_rabbitmq"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "amqp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "pubsub_zeromq"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "logger 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "zmq 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "rlp"
 version = "0.2.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "rlp_derive"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2806,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "snappy"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3313,7 +3313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "tx_pool"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -3429,7 +3429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "util"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#ee54d9c523dacab691b0f046f2136aef63a457db"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#9f1a82d68de2aeca0ad209a51b6e0df68a410b87"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",

--- a/cita-executor/core/src/snapshot/account.rs
+++ b/cita-executor/core/src/snapshot/account.rs
@@ -133,7 +133,7 @@ pub fn to_fat_rlps(
         }
 
         account_stream.begin_unbounded_list();
-        if account_stream.len() > target_chunk_size {
+        if account_stream.size() > target_chunk_size {
             // account does not fit, push an empty record to mark a new chunk
             target_chunk_size = max_chunk_size;
             chunks.push(Vec::new());

--- a/tools/bft-wal/src/main.rs
+++ b/tools/bft-wal/src/main.rs
@@ -43,7 +43,7 @@ impl OldAuthorityManage {
         let mut authority_manage = Self {
             authorities: Vec::new(),
             authority_n: 0,
-            authorities_log: Wal::new(&*logpath).unwrap(),
+            authorities_log: Wal::create(&*logpath).unwrap(),
             authorities_old: Vec::new(),
             authority_n_old: 0,
             authority_h_old: 0,


### PR DESCRIPTION
#### Description of the Change
Add `from` to `body` of `getBlockByNumber` and `getBlockByHash`

![image](https://user-images.githubusercontent.com/13375784/53335457-7d9d7880-3936-11e9-907a-88eefbdf36d8.png)

#### Applicable Issues
ref #229 