### PR TITLE
Remove redundant RwLock.

### DIFF
--- a/cita-chain/core/src/libchain/chain.rs
+++ b/cita-chain/core/src/libchain/chain.rs
@@ -260,7 +260,6 @@ impl BloomGroupDatabase for Chain {
         let position = LogGroupPosition::from(position.clone());
         let result = self
             .db
-            .read()
             .read_with_cache(db::COL_EXTRA, &self.blocks_blooms, &position)
             .map(Into::into);
         self.cache_man
@@ -286,7 +285,7 @@ pub struct Chain {
     pub max_store_height: AtomicUsize,
     pub block_map: RwLock<BTreeMap<u64, BlockInQueue>>,
     pub proof_map: RwLock<BTreeMap<u64, ProtoProof>>,
-    pub db: RwLock<Arc<KeyValueDB>>,
+    pub db: Arc<KeyValueDB>,
 
     // block cache
     pub block_headers: RwLock<HashMap<BlockNumber, Header>>,
@@ -394,7 +393,7 @@ impl Chain {
             blocks_blooms: RwLock::new(HashMap::new()),
             block_receipts: RwLock::new(HashMap::new()),
             cache_man: Mutex::new(cache_man),
-            db: RwLock::new(db),
+            db,
             polls_filter: Arc::new(Mutex::new(PollManager::default())),
             nodes: RwLock::new(Vec::new()),
             validators: RwLock::new(Vec::new()),
@@ -451,7 +450,6 @@ impl Chain {
     pub fn block_height_by_hash(&self, hash: H256) -> Option<BlockNumber> {
         let result = self
             .db
-            .read()
             .read_with_cache(db::COL_EXTRA, &self.block_hashes, &hash);
         self.cache_man.lock().note_used(CacheId::BlockHashes(hash));
         result
@@ -606,7 +604,7 @@ impl Chain {
         }
 
         batch.write(db::COL_EXTRA, &CurrentHash, &hash);
-        self.db.read().write(batch).expect("DB write failed.");
+        self.db.write(batch).expect("DB write failed.");
         {
             *self.current_header.write() = hdr;
         }
@@ -774,7 +772,6 @@ impl Chain {
         }
         let result = self
             .db
-            .read()
             .read_with_cache(db::COL_HEADERS, &self.block_headers, &idx);
         self.cache_man.lock().note_used(CacheId::BlockHeaders(idx));
         result
@@ -806,7 +803,6 @@ impl Chain {
     fn block_body_by_height(&self, number: BlockNumber) -> Option<BlockBody> {
         let result = self
             .db
-            .read()
             .read_with_cache(db::COL_BODIES, &self.block_bodies, &number);
         self.cache_man
             .lock()
@@ -831,10 +827,9 @@ impl Chain {
 
     /// Get address of transaction by hash.
     fn transaction_address(&self, hash: TransactionId) -> Option<TransactionAddress> {
-        let result =
-            self.db
-                .read()
-                .read_with_cache(db::COL_EXTRA, &self.transaction_addresses, &hash);
+        let result = self
+            .db
+            .read_with_cache(db::COL_EXTRA, &self.transaction_addresses, &hash);
         self.cache_man
             .lock()
             .note_used(CacheId::TransactionAddresses(hash));
@@ -1076,14 +1071,13 @@ impl Chain {
 
     #[inline]
     pub fn current_block_poof(&self) -> Option<ProtoProof> {
-        self.db.read().read(db::COL_EXTRA, &CurrentProof)
+        self.db.read(db::COL_EXTRA, &CurrentProof)
     }
 
     pub fn save_current_block_poof(&self, proof: &ProtoProof) {
         let mut batch = DBTransaction::new();
         batch.write(db::COL_EXTRA, &CurrentProof, proof);
         self.db
-            .read()
             .write(batch)
             .expect("save_current_block_poof DB write failed.");
     }
@@ -1298,7 +1292,6 @@ impl Chain {
     pub fn block_receipts(&self, hash: H256) -> Option<BlockReceipts> {
         let result = self
             .db
-            .read()
             .read_with_cache(db::COL_EXTRA, &self.block_receipts, &hash);
         self.cache_man
             .lock()
@@ -1406,7 +1399,7 @@ impl Chain {
                 .note_used(CacheId::BlockBodies(height as BlockNumber));
         }
         batch.write(db::COL_EXTRA, &CurrentHeight, &height);
-        let _ = self.db.read().write(batch);
+        let _ = self.db.write(batch);
     }
 
     pub fn compare_status(&self, st: &Status) -> (u64, u64) {

--- a/cita-chain/core/src/snapshot/service.rs
+++ b/cita-chain/core/src/snapshot/service.rs
@@ -58,12 +58,11 @@ impl DatabaseRestore for Chain {
     fn restore_db(&self, new_db: &str) -> Result<(), Error> {
         info!("Replacing client database with {:?}", new_db);
 
-        let db = self.db.write();
-        db.restore(new_db)?;
+        self.db.restore(new_db)?;
 
         // replace chain
         //*chain = Arc::new(BlockChain::new(self.config.blockchain.clone(), &[], db.clone()));
-        let header = get_chain(&*db.clone()).expect("Get chain failed");
+        let header = get_chain(&*self.db.clone()).expect("Get chain failed");
 
         let current_height = header.number();
 
@@ -73,7 +72,7 @@ impl DatabaseRestore for Chain {
         self.current_height
             .store(current_height as usize, Ordering::SeqCst);
 
-        if let Some(height) = get_chain_body_height(&*db.clone()) {
+        if let Some(height) = get_chain_body_height(&*self.db.clone()) {
             self.max_store_height
                 .store(height as usize, Ordering::SeqCst);
         }

--- a/cita-executor/core/src/contracts/grpc/grpc_vm.rs
+++ b/cita-executor/core/src/contracts/grpc/grpc_vm.rs
@@ -99,9 +99,9 @@ impl<'a, B: 'a + StateBackend> CallEvmImpl<'a, B> {
 
     pub fn save_contract_state(&mut self, executor: &Executor, contract_state: &ContractState) {
         let addr = contract_state.get_address();
-        let mut batch = executor.db.read().transaction();
+        let mut batch = executor.db.transaction();
         batch.write(db::COL_EXTRA, &addr, contract_state);
-        executor.db.read().write(batch).unwrap();
+        executor.db.write(batch).unwrap();
         service_registry::set_enable_contract_height(addr, contract_state.height);
     }
 

--- a/cita-executor/core/src/libexecutor/command.rs
+++ b/cita-executor/core/src/libexecutor/command.rs
@@ -470,7 +470,7 @@ impl Commander for Executor {
 
     fn clone_executor_reader(&mut self) -> Self {
         let current_header = self.current_header.read().clone();
-        let db = self.db.read().clone();
+        let db = self.db.clone();
         let fake_parent_hash: H256 = Default::default();
         let state_db = self.state_db.read().boxed_clone_canon(&fake_parent_hash);
         let factories = self.factories.clone();
@@ -483,7 +483,7 @@ impl Commander for Executor {
         let eth_compatibility = self.eth_compatibility;
         Executor {
             current_header: RwLock::new(current_header),
-            db: RwLock::new(db),
+            db,
             state_db: Arc::new(RwLock::new(state_db)),
             factories,
             sys_config,


### PR DESCRIPTION
- `RwLock<Arc<T>>` is incorrect use, should be `Arc<RwLock<T>>`.
- `RwLock` is redundant since [all APIs for `Database`] do not need `mutable`.

[all APIs for `Database`]: https://github.com/cryptape/cita-common/blob/c3b60920b31697eaeb625dd0585068b7d277968b/db/src/kvdb/rocksdb.rs#L258-L737