### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ jobs:
   include:
 
     - stage: Release
+      name: Release for Integrate Test
+      language: node_js
+      node_js:
+        - lts/*
       cache:
         directories:
           - $TRAVIS_BUILD_DIR/target/release-cache
@@ -42,6 +46,7 @@ jobs:
       cache:
         directories:
           - $TRAVIS_BUILD_DIR/target/release-cache
+      env: HASH_ALGO=sha3hash    CRYPTO_ALGO=secp256k1
       before_install:
         - cd $TRAVIS_BUILD_DIR
         - rm -rf target/install


### PR DESCRIPTION
Travis CI was [broken](https://travis-ci.com/cryptape/cita/builds/102146960) since #249.

For PRs which are update CI scripts, we should clean CI caches before push commits.

##### [Travis CI: Caching Dependencies and Directories - Caches and build matrices]

> When you have multiple jobs in a build matrix, some characteristics of each job are used to identify the cache each of the jobs should use.
> 
> These factors are:
> 
> 1. OS name (currently, `linux` or `osx`)
> 2. OS distribution (for Linux, `xenial`, `trusty`, or `precise`)
> 3. macOS image name (e.g., `xcode7.2`)
> 4. Names and values of visible environment variables set in `.travis.yml` or Settings panel
> 5. Language runtime version (for the language specified in the `language key`) if applicable
> 6. For Bundler-aware jobs, the name of the `Gemfile` used
>
> If these characteristics are shared by more than one job in a build matrix, they will share the same URL on the network. This could corrupt the cache, or the cache may contain files that are not usable in all jobs using it. In this case, we advise you to add a public environment variable name to each job to create a unique cache entry:

#249 changed 4 and 5.

[Travis CI: Caching Dependencies and Directories - Caches and build matrices]: https://docs.travis-ci.com/user/caching/#caches-and-build-matrices