### PR TITLE
Revert "remove unused db column"

### DIFF
--- a/cita-chain/types/src/db.rs
+++ b/cita-chain/types/src/db.rs
@@ -36,8 +36,10 @@ pub const COL_EXTRA: Option<u32> = Some(3);
 pub const COL_TRACE: Option<u32> = Some(4);
 /// Column for the empty accounts bloom filter.
 pub const COL_ACCOUNT_BLOOM: Option<u32> = Some(5);
+/// Column for general information from the local node which can persist.
+pub const COL_NODE_INFO: Option<u32> = Some(6);
 /// Number of columns in DB
-pub const NUM_COLUMNS: Option<u32> = Some(6);
+pub const NUM_COLUMNS: Option<u32> = Some(7);
 
 /// Modes for updating caches.
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Reverts cryptape/cita#296

reduce column family's count will cause program  to check old db's table info for long time and then failed