### PR TITLE
Fix JSON-RPC CORS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Following [Upgrade Instructions](https://docs.citahub.com/en-US/cita/protocol-up
 The new feature of integrating p2p to network service, we add discovery of the network node
 when the original configuration is compatible. But we still need to make some changes to the
 network configuration file definition:
-  
+
 The old version `network.toml` looks like:
 
 ```toml
@@ -63,6 +63,7 @@ But in v0.22.0, the item `[[peers]]` means `known nodes` in the network, you can
 
 - [Optimization] Update test token info. [@kaikai]
 - [Feature] Add `from` to `body` of `getBlockByNumber` and `getBlockByHash`. [@CL]
+- [Fix] Fix the missing CORS header. [@yangby]
 
 ### Scripts
 

--- a/cita-jsonrpc/src/http_header.rs
+++ b/cita-jsonrpc/src/http_header.rs
@@ -18,7 +18,7 @@
 use hyper::header::{HeaderMap, HeaderName, HeaderValue, InvalidHeaderValue};
 
 pub const ORIGIN_ANY_STR: &str = "*";
-pub const ORIGIN_NULL_STR: &str = "";
+pub const ORIGIN_NULL_STR: &str = "null";
 
 // values come from hyper 0.11
 pub const CONTENT_TYPE_PLAIN_TEXT_STR: &str = "text/plain; charset=utf-8";
@@ -174,7 +174,7 @@ mod test {
 
     #[test]
     fn test_origin_null() {
-        assert_eq!(Origin::null(), HeaderValue::from_static(""));
+        assert_eq!(Origin::null(), HeaderValue::from_static("null"));
     }
 
     #[test]
@@ -192,9 +192,9 @@ mod test {
         vec![
             (Some("*"), HeaderValue::from_static("*")),
             (Some(" * "), HeaderValue::from_static("*")),
-            (None, HeaderValue::from_static("")),
-            (Some(""), HeaderValue::from_static("")),
-            (Some("   null "), HeaderValue::from_static("")),
+            (None, HeaderValue::from_static("null")),
+            (Some(""), HeaderValue::from_static("null")),
+            (Some("   null "), HeaderValue::from_static("null")),
             (Some("abc"), HeaderValue::from_static("abc")),
             (Some(" xyz "), HeaderValue::from_static("xyz")),
         ]

--- a/cita-jsonrpc/src/http_server.rs
+++ b/cita-jsonrpc/src/http_server.rs
@@ -18,7 +18,8 @@
 use futures::future::{self as future, Future};
 use hyper::header::{
     HeaderMap as Headers, HeaderName, HeaderValue, ACCEPT, ACCESS_CONTROL_ALLOW_HEADERS,
-    ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_MAX_AGE, CONTENT_TYPE, ORIGIN, USER_AGENT,
+    ACCESS_CONTROL_ALLOW_METHODS, ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_MAX_AGE,
+    CONTENT_TYPE, ORIGIN, USER_AGENT,
 };
 use hyper::service::{MakeService, Service};
 use hyper::{Body, Method, Request, Response, StatusCode};
@@ -249,7 +250,7 @@ impl Server {
 
         let mut http_headers = Headers::new();
         http_headers.insert(CONTENT_TYPE, json);
-        http_headers.insert(ORIGIN, allow_origin);
+        http_headers.insert(ACCESS_CONTROL_ALLOW_ORIGIN, allow_origin);
 
         let make_jsonrpc_svc = JsonrpcMakeService {
             inner: Arc::new(Inner {

--- a/tests/integrate_test/cita_jsonrpcTest.sh
+++ b/tests/integrate_test/cita_jsonrpcTest.sh
@@ -34,6 +34,11 @@ invalid_data=-32600
 invalid_jsonrpc_method=-32601
 
 ./cita_start.sh
+
+# Check JSON-RPC CORS: Access-Control-Allow-Origin should be existed.
+has_cors=$(curl -i -X POST -d '{"jsonrpc":"2.0","method":"peerCount","params":[],"id":2}'  $IP:$PORT 2>/dev/null | grep -ic "^access-control-allow-origin: ")
+assert ${has_cors} 1 "Check JSON-RPC CORS"
+
 ## request of invalid http method
 err_code=`curl -s -X GET -d '{"jsonrpc":"2.0","method":"peerCount","params":[],"id":2}' $IP:$PORT | jq ".error.code"`
 assert $err_code $invalid_http_method "request of invalid http method"


### PR DESCRIPTION
- The [`Access-Control-Allow-Origin`] is not right.
  Should be `Access-Control-Allow-Origin`, but we write `Origin`.

- The [`Access-Control-Allow-Origin`] should be `*`, `<origin>` or `null`.
  The empty string is not in the specification.

- Add a simple test to test if [`Access-Control-Allow-Origin`] is existed in JSON-RPC's responses.

[`Access-Control-Allow-Origin`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#Syntax