### PR TITLE
Set the default ntp service to false.

### DIFF
--- a/scripts/config_tool/config_example/consensus.toml
+++ b/scripts/config_tool/config_example/consensus.toml
@@ -1,4 +1,4 @@
 [ntp_config]
-enabled = true
+enabled = false
 threshold = 1000
 address = "0.pool.ntp.org:123"


### PR DESCRIPTION
#### Description of the Change

ntp service will not be used at new cita-bft.
So set it to false to avoid the useless warning.

#### Applicable Issues

#298 