### PR TITLE
Add cita formula.

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 
-SOURCE_DIR="$(cd $(dirname "$0") && pwd -P)"
+if [ `uname` == 'Darwin' ]; then
+    SYSTEM_NET="bridge"
+    SOURCE_DIR="$(dirname $(realpath $0))"
+else
+    SYSTEM_NET="host"
+    SOURCE_DIR="$(dirname $(readlink -f $0))"
+fi
+
+cp /etc/localtime ${SOURCE_DIR}/localtime
+LOCALTIME_PATH="${SOURCE_DIR}/localtime"
 
 test -f "${SOURCE_DIR}/CODE_OF_CONDUCT.md"
 if [ $? -eq 0 ]; then
@@ -10,15 +19,6 @@ else
     CONTAINER_NAME="cita_run_container"
     DOCKER_IMAGE="cita/cita-run:ubuntu-18.04-20181009"
     SOURCE_DIR="$(dirname $SOURCE_DIR)"
-fi
-
-if [ `uname` == 'Darwin' ]; then
-    cp /etc/localtime ${SOURCE_DIR}/localtime
-    SYSTEM_NET="bridge"
-    LOCALTIME_PATH="${SOURCE_DIR}/localtime"
-else
-    SYSTEM_NET="host"
-    LOCALTIME_PATH="/etc/localtime"
 fi
 
 WORKDIR=/opt/cita
@@ -58,8 +58,8 @@ if [ $? -ne 0 ]; then
     docker run -d \
            --net=${SYSTEM_NET} \
            --volume ${SOURCE_DIR}:${WORKDIR} \
-           --volume ${DOCKER_CARGO}/git:${DOCKER_CARGO}/git \
-           --volume ${DOCKER_CARGO}/registry:${DOCKER_CARGO}/registry \
+           --volume ${DOCKER_CARGO}/git:${CARGO_HOME}/git \
+           --volume ${DOCKER_CARGO}/registry:${CARGO_HOME}/registry \
            --volume ${LOCALTIME_PATH}:/etc/localtime \
            --env USER_ID=${USER_ID} \
            --workdir ${WORKDIR} \

--- a/formula/cita.rb
+++ b/formula/cita.rb
@@ -1,0 +1,42 @@
+# CITA Formula
+class Cita < Formula
+  desc "A high performance blockchain for enterprise users."
+  homepage "https://github.com/cryptape/cita"
+
+  version "0.22"
+  url "https://github.com/cryptape/cita/releases/download/v0.22.0/cita_secp256k1_sha3.tar.gz"
+  sha256 "3f28abc41f98b4e2dc5122ad72d8032a1fb09751d148ab6483e9c2e50af7800d"
+  resource "cita" do
+    url "https://github.com/cryptape/cita.git",
+        :branch => "develop"
+    # Completing at v0.23
+    # :tag => ""
+    # :revision => ""
+  end
+
+  def install
+    libexec.install Dir["*"]
+
+    resource("cita").stage do
+      system  "cp", "-r", "env.sh", "#{libexec}/bin/cita-env"
+      system  "cp", "-r", "scripts/cita", "#{libexec}/bin/cita"
+      system  "cp", "-r", "scripts/cita_config.sh", "#{libexec}/bin/cita-config"
+    end
+
+    bin.install_symlink Dir["#{libexec}/bin/cita"]
+    bin.install_symlink Dir["#{libexec}/bin/cita-env"]
+    bin.install_symlink Dir["#{libexec}/bin/cita-config"]
+  end
+
+  def caveats; <<~EOS
+     By default, binaries installed by cita will be placed into:
+     #{libexec}
+     Usage: cita_commander <command> <node> [options]
+     where <command> is one of the following:
+         { help | create | port | setup | start | stop | restart
+           ping | top | backup | clean | logs | logrotate }
+     Run `cita help` for more detailed information.
+     happy hacking!
+  EOS
+  end
+end

--- a/scripts/cita
+++ b/scripts/cita
@@ -2,8 +2,12 @@
 # -*- tab-width:4;indent-tabs-mode:nil -*-
 # ex: ts=4 sw=4 et
 
-# Commands Paths
-CITA_BIN="$(cd $(dirname "$0") && pwd -P)"
+# Exec-Script Path
+if [ `uname` == 'Darwin' ]; then
+    CITA_BIN="$(dirname $(realpath $0))"
+else
+    CITA_BIN="$(dirname $(readlink -f $0))"
+fi
 CITA_SCRIPTS="$(dirname $CITA_BIN)/scripts"
 
 if [ "$1" != "bebop" ]; then
@@ -181,11 +185,11 @@ do_start() {
 
     # Start cita-forever
     if [ -z ${debug} ]; then
-        cita-forever -c ${config} start 2>&1
+        cita-forever -c ${config} start > /dev/null 2>&1
     else
         RUST_LOG=cita_auth=${debug},cita_chain=${debug},cita_executor=${debug},cita_jsonrpc=${debug},cita_network=${debug},cita_bft=${debug},\
 core_executor=${debug},engine=${debug},jsonrpc_types=${debug},libproto=${debug},proof=${debug},txpool=${debug},core=${debug} \
-        cita-forever -c ${config} start 2>&1
+        cita-forever -c ${config} start /dev/null 2>&1
     fi
 
     # Wait for the node to come up
@@ -195,7 +199,6 @@ core_executor=${debug},engine=${debug},jsonrpc_types=${debug},libproto=${debug},
         sleep 1
         do_ping
         if [ "${PING_STATUS}" == "pong" ]; then
-            echo "start...ok"
             exit 0
         fi
     done
@@ -431,6 +434,7 @@ case "${COMMAND}" in
         do_ping
         if [ "${PING_STATUS}" == "pong" ]; then
             echo "pong"
+            exit 0
         else
             echo "Node '${NODE_NAME}' not responding to pings."
             exit 1

--- a/scripts/cita
+++ b/scripts/cita
@@ -185,11 +185,11 @@ do_start() {
 
     # Start cita-forever
     if [ -z ${debug} ]; then
-        cita-forever -c ${config} start > /dev/null 2>&1
+        cita-forever -c ${config} start 2>&1
     else
         RUST_LOG=cita_auth=${debug},cita_chain=${debug},cita_executor=${debug},cita_jsonrpc=${debug},cita_network=${debug},cita_bft=${debug},\
 core_executor=${debug},engine=${debug},jsonrpc_types=${debug},libproto=${debug},proof=${debug},txpool=${debug},core=${debug} \
-        cita-forever -c ${config} start /dev/null 2>&1
+        cita-forever -c ${config} start 2>&1
     fi
 
     # Wait for the node to come up

--- a/scripts/cita_config.sh
+++ b/scripts/cita_config.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 # Enviroments
-CITA_BIN=$(realpath $(dirnamme $0))
+if [ `uname` == 'Darwin' ]; then
+    CITA_BIN="$(dirname $(realpath $0))"
+else
+    CITA_BIN="$(dirname $(readlink -f $0))"
+fi
 CITA_SCRIPTS=$(dirname $CITA_BIN)/scripts
 
 # Wrap the create script.
@@ -9,3 +13,4 @@ if [ -e $CITA_SCRIPTS/create_cita_config.py ]; then
     $CITA_SCRIPTS/create_cita_config.py $@
 else
     echo -e "\033[0;31mPlease run this command after build 🎨"
+fi


### PR DESCRIPTION
## CircleCi
well, the circleCI seems failed with connecting nodes in some tests...XD, I'll try to fix them the day after tomorrow If they're not network errors. (I have to write my graduation thesis tomorrow)

## Diff
1. Added `cita.rb`
2. Modified the way of getting absolute path from `$(cd $(dirname $0) && pwd -P )` into `realpath` and `readlink -f`, because the `pwd` method still not friendly to symlinks.
3. Modified `cita-forever`'s stdout to `cita-forever -c ${config} start > /dev/null 2>&1` in `cita script`, I'm not sure about this, but `2>&1` directly causes a bug in my PC —— keyboard stdin messed up after `cita start`, `cita ping` will not work...XD(might be my last pr's fault)

## Note
1. This script choose `secp256k1` algorithm by default, the reason is the `secp256k1` versioned `cita-cli` installing easily, and `cita-sdk-js` might not be happy with `ed25519` [recently][1]...
2. May be cita team can new a repo named `homebrew-cita` so users can use `brew tap cryptape/cita` installing cita directly, or pr the `cita.rb` to [homebrew-core][2] after cita have released stable version? `brew install cita` directly might be the best choice~

## Installation

#### Install docker
_To run cita happily, we need to install docker first._
```
brew cask install docker
```

#### Curl formula and install.

```sh
# curl https://raw.githubusercontent.com/clearloop/cita/develop/formula/cita.rb -o cita.rb
curl https://raw.githubusercontent.com/cryptape/cita/develop/formula/cita.rb -o cita.rb
brew install ./cita.rb
```

By default, binaries installed by cita will be placed into:
  
```
/usr/local/Cellar/cita/0.22
```

Run `cita help` for more detailed information.


#### One more thing

Click docker icon, and share `/usr/local/Cellar/cita`.


## Getting-Started

#### Create Chain

```
$ cita create --chain_name "cita_block_chain" --super_admin "0x4b5ae4567ad5d9fb92bc9afd6a657e6fa13a2523" --nodes "127.0.0.1:4000,127.0.0.1:4001,127.0.0.1:4002,127.0.0.1:4003"
```

#### Setup Chain

```
$ cita setup test-chain/0
```

#### Start Chain
```
$ cita start test-chain/0
```

#### Stop Chain
```
$ cita stop test-chain/0
```

#### Usages
```
$ cita
Usage: cita <command> <node> [options]
where <command> is one of the following:
    { help | create | port | setup | start | stop | restart
      ping | top | backup | clean | logs | logrotate }
Run `cita help` for more detailed information.
```

## Presets

_Here are some default sets, you can reset them on your own:_

#### Set Port

```
$ cita port 42:42
# The docker port is `1337:1337` by default, if you need to, use this._
```
[1]: https://talk.citahub.com/t/topic/334
[2]: https://github.com/Homebrew/homebrew-core