### PR TITLE
Integrate evm test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 	path = scripts/config_tool/genesis
 	url = https://github.com/cryptape/genesis.git
 	branch = v0.22.0
+[submodule "tests/jsondata"]
+	path = tests/jsondata
+	url = https://github.com/ethereum/tests.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,7 +1300,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1321,7 +1321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fixed-hash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1329,8 +1329,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethereum-types"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fixed-hash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ethereum-types-serialize"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2877,6 +2890,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-hex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,6 +3734,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crunchy 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicase"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3850,6 +3879,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vm_test"
+version = "0.1.0"
+dependencies = [
+ "core-executor 0.1.0",
+ "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "evm 0.1.0",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "void"
@@ -4101,7 +4143,8 @@ dependencies = [
 "checksum ethbloom 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a93a43ce2e9f09071449da36bfa7a1b20b950ee344b6904ff23de493b03b386"
 "checksum ethcore-bloom-journal 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)" = "<none>"
 "checksum ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c48729b8aea8aedb12cf4cb2e5cef439fdfe2dda4a89e47eeebd15778ef53b6"
-"checksum ethereum-types-serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ac59a21a9ce98e188f3dace9eb67a6c4a3c67ec7fbc7218cb827852679dc002"
+"checksum ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e742184dc63a01c8ea0637369f8faa27c40f537949908a237f95c05e68d2c96"
+"checksum ethereum-types-serialize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1873d77b32bc1891a79dad925f2acbc318ee942b38b9110f9dbc5fbeffcea350"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
 "checksum failure_derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "64c2d913fe8ed3b6c6518eedf4538255b989945c14c2a7d5cbff62a5e2120596"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
@@ -4266,6 +4309,7 @@ dependencies = [
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ceb8ce7a5e520de349e1fa172baeba4a9e8d5ef06c47471863530bc4972ee1e"
+"checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
@@ -4353,6 +4397,7 @@ dependencies = [
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum uint 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "38051a96565903d81c9a9210ce11076b2218f3b352926baa1f5f6abbdfce8273"
+"checksum uint 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "754ba11732b9161b94c41798e5197e5e75388d012f760c42adb5000353e98646"
 "checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = ["cita-auth"
 ,"tests/consensus-mock"
 ,"tests/chain_performance_by_mq"
 ,"tests/box_executor"
+,"tests/vm_test"
 ]
 
 [profile.bench]

--- a/cita-executor/evm/src/fake_tests.rs
+++ b/cita-executor/evm/src/fake_tests.rs
@@ -58,7 +58,7 @@ pub struct FakeExt {
     pub blockhashes: HashMap<U256, H256>,
     pub codes: HashMap<Address, Arc<Bytes>>,
     pub logs: Vec<FakeLogEntry>,
-    pub _suicides: HashSet<Address>,
+    pub suicides: HashSet<Address>,
     pub info: EnvInfo,
     pub schedule: Schedule,
     pub balances: HashMap<Address, U256>,
@@ -106,7 +106,7 @@ impl Ext for FakeExt {
     }
 
     fn origin_balance(&self) -> error::Result<U256> {
-        unimplemented!()
+        Ok(U256::from(0))
     }
 
     fn balance(&self, address: &Address) -> error::Result<U256> {
@@ -178,7 +178,8 @@ impl Ext for FakeExt {
     }
 
     fn suicide(&mut self, _refund_address: &Address) -> error::Result<()> {
-        unimplemented!();
+        self.suicides.insert(_refund_address.clone());
+        Ok(())
     }
 
     fn schedule(&self) -> &Schedule {

--- a/cita-executor/evm/src/lib.rs
+++ b/cita-executor/evm/src/lib.rs
@@ -17,7 +17,7 @@
 //! Ethereum virtual machine.
 
 extern crate bit_set;
-extern crate cita_types;
+pub extern crate cita_types;
 extern crate common_types as types;
 extern crate db as cita_db;
 extern crate hashable;

--- a/tests/vm_test/Cargo.toml
+++ b/tests/vm_test/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vm_test"
+version = "0.1.0"
+authors = ["Cryptape Technologies <contact@cryptape.com>"]
+
+[dependencies]
+ethereum-types = "0.4.0"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+hex = "0.3"
+
+core-executor = { path="../../cita-executor/core"}
+evm = { path="../../cita-executor/evm"}

--- a/tests/vm_test/README.md
+++ b/tests/vm_test/README.md
@@ -1,0 +1,12 @@
+# Vm Test
+
+Test the cita vm using [Tests](https://github.com/ethereum/tests/blob/develop/VMTests/)
+
+
+## Usage
+
+```sh
+$ cd cita
+
+$ RUST_BACKTRACE=1 cargo run --bin vm_test
+```

--- a/tests/vm_test/src/helper.rs
+++ b/tests/vm_test/src/helper.rs
@@ -1,0 +1,43 @@
+use evm::cita_types::{Address, H256, U256};
+
+pub fn clean_0x(s: &str) -> &str {
+    if s.starts_with("0x") {
+        &s[2..]
+    } else {
+        s
+    }
+}
+
+pub fn string_2_u256(value: String) -> U256 {
+    let v = Box::leak(value.into_boxed_str());
+    let v = clean_0x(v);
+    U256::from(v)
+}
+
+pub fn string_2_h256(value: String) -> H256 {
+    let v = Box::leak(value.into_boxed_str());
+    let v = clean_0x(v);
+    if v.len() < 64 {
+        let mut s = String::from("0").repeat(64 - v.len());
+        s.push_str(v);
+        let s: &'static str = Box::leak(s.into_boxed_str());
+        return H256::from(s);
+    }
+    H256::from(v)
+}
+
+pub fn string_2_bytes(value: String) -> Vec<u8> {
+    let v = Box::leak(value.into_boxed_str());
+    let v = clean_0x(v);
+    hex::decode(v).unwrap()
+}
+
+#[allow(dead_code)]
+pub fn string_2_address(value: String) -> Address {
+    if value.is_empty() {
+        return Address::zero();
+    }
+    let v = Box::leak(value.into_boxed_str());
+    let v = clean_0x(v);
+    Address::from(v)
+}

--- a/tests/vm_test/src/json.rs
+++ b/tests/vm_test/src/json.rs
@@ -1,0 +1,187 @@
+extern crate evm;
+extern crate serde_derive;
+
+use self::evm::cita_types::Address;
+use self::serde_derive::Deserialize;
+use std::collections::BTreeMap;
+use std::io::Read;
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Test(BTreeMap<String, Vm>);
+
+impl IntoIterator for Test {
+    type Item = <BTreeMap<String, Vm> as IntoIterator>::Item;
+    type IntoIter = <BTreeMap<String, Vm> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Test {
+    pub fn load<R>(reader: R) -> Result<Self, serde_json::Error>
+    where
+        R: Read,
+    {
+        serde_json::from_reader(reader)
+    }
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Vm {
+    #[serde(rename = "callcreates")]
+    pub call_creates: Option<Vec<Callcreates>>,
+
+    #[serde(rename = "env")]
+    pub env: Env,
+
+    #[serde(rename = "exec")]
+    pub exec: Exec,
+
+    #[serde(rename = "gas")]
+    pub gas: Option<String>,
+
+    #[serde(rename = "logs")]
+    pub logs: Option<String>,
+
+    #[serde(rename = "out")]
+    pub out: Option<String>,
+
+    #[serde(rename = "post")]
+    pub post: Option<State>,
+
+    #[serde(rename = "pre")]
+    pub pre: Option<State>,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Callcreates {}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Env {
+    #[serde(rename = "currentCoinbase")]
+    pub current_coinbase: Address,
+
+    #[serde(rename = "currentDifficulty")]
+    pub current_difficulty: String,
+
+    #[serde(rename = "currentGasLimit")]
+    pub current_gas_limit: String,
+
+    #[serde(rename = "currentNumber")]
+    pub current_number: String,
+
+    #[serde(rename = "currentTimestamp")]
+    pub current_timestamp: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Exec {
+    #[serde(rename = "address")]
+    pub address: Address,
+
+    #[serde(rename = "caller")]
+    pub caller: Address,
+
+    #[serde(rename = "code")]
+    pub code: String,
+
+    #[serde(rename = "data")]
+    pub data: String,
+
+    #[serde(rename = "gas")]
+    pub gas: String,
+
+    #[serde(rename = "gasPrice")]
+    pub gas_price: String,
+
+    #[serde(rename = "origin")]
+    pub origin: Address,
+
+    #[serde(rename = "value")]
+    pub value: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Clone)]
+pub struct Account {
+    pub balance: String,
+    pub code: String,
+    pub nonce: String,
+    pub storage: BTreeMap<String, String>,
+}
+
+#[derive(Debug, PartialEq, Deserialize, Clone)]
+pub struct State(BTreeMap<Address, Account>);
+
+impl IntoIterator for State {
+    type Item = <BTreeMap<Address, Account> as IntoIterator>::Item;
+    type IntoIter = <BTreeMap<Address, Account> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_json_tests_parse() {
+        let f = fs::File::open("../jsondata/VMTests/vmArithmeticTest/add0.json").unwrap();
+        let t = Test::load(f).unwrap();
+        assert!(t.0.contains_key("add0"));
+        let v = &t.0["add0"];
+
+        assert_eq!(
+            v.env.current_coinbase,
+            Address::from("0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba")
+        );
+        assert_eq!(v.env.current_difficulty, String::from("0x0100"));
+        assert_eq!(v.env.current_gas_limit, String::from("0x0f4240"));
+        assert_eq!(v.env.current_number, String::from("0x00"));
+        assert_eq!(v.env.current_timestamp, String::from("0x01"));
+
+        assert_eq!(
+            v.exec.address,
+            Address::from("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")
+        );
+        assert_eq!(
+            v.exec.caller,
+            Address::from("0xcd1722f2947def4cf144679da39c4c32bdc35681")
+        );
+        assert_eq!(v.exec.data, String::from("0x"));
+        assert_eq!(v.exec.gas, String::from("0x0186a0"));
+        assert_eq!(v.exec.gas_price, String::from("0x5af3107a4000"));
+        assert_eq!(
+            v.exec.origin,
+            Address::from("0xcd1722f2947def4cf144679da39c4c32bdc35681")
+        );
+        assert_eq!(v.exec.value, String::from("0x0de0b6b3a7640000"));
+
+        assert_eq!(v.gas, Some(String::from("0x013874")));
+        assert_eq!(
+            v.logs,
+            Some(String::from(
+                "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347"
+            ))
+        );
+        assert_eq!(v.out, Some(String::from("0x")));
+
+        if let Some(data) = &v.post {
+            let post_account =
+                &data.0[&Address::from("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")];
+            assert_eq!(post_account.balance, String::from("0x0de0b6b3a7640000"));
+            assert_eq!(
+                post_account.storage[&String::from("0x00")],
+                String::from("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe")
+            )
+        }
+
+        if let Some(data) = &v.pre {
+            let pre_account = &data.0[&Address::from("0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6")];
+            assert_eq!(pre_account.balance, String::from("0x0de0b6b3a7640000"));
+        }
+    }
+}

--- a/tests/vm_test/src/main.rs
+++ b/tests/vm_test/src/main.rs
@@ -1,0 +1,102 @@
+extern crate core_executor;
+extern crate evm;
+
+mod helper;
+mod json;
+
+use evm::action_params::{ActionParams, ActionValue};
+use evm::env_info::EnvInfo;
+use evm::factory::{Factory, VMType};
+use evm::fake_tests::FakeExt;
+use evm::return_data::GasLeft;
+use evm::Ext;
+use helper::{string_2_bytes, string_2_h256, string_2_u256};
+use std::fs;
+use std::str;
+use std::sync::Arc;
+
+fn test_json_file(p: &str) {
+    println!("{}", p);
+    let f = fs::File::open(p).unwrap();
+    let tests = json::Test::load(f).unwrap();
+    for (_name, vm) in tests.into_iter() {
+        // Step one: Init params, env_info
+        let mut params = ActionParams::default();
+        params.address = vm.exec.address;
+        params.sender = vm.exec.caller;
+        params.code = Some(Arc::new(string_2_bytes(vm.exec.code)));
+        params.data = Some(string_2_bytes(vm.exec.data));
+        params.gas = string_2_u256(vm.exec.gas);
+        params.gas_price = string_2_u256(vm.exec.gas_price);
+        params.origin = vm.exec.origin;
+        params.value = ActionValue::Apparent(string_2_u256(vm.exec.value));
+
+        let mut env_info = EnvInfo::default();
+        env_info.difficulty = string_2_u256(vm.env.current_difficulty);
+        env_info.number = string_2_u256(vm.env.current_number).low_u64();
+        env_info.timestamp = string_2_u256(vm.env.current_timestamp).low_u64();
+        env_info.gas_limit = string_2_u256(vm.env.current_gas_limit);
+        env_info.author = vm.env.current_coinbase;
+
+        // Step two: Vm exec process
+        let factory = Factory::new(VMType::Interpreter, 1024 * 32);
+        let mut evm = factory.create(params.gas);
+        let mut ext = FakeExt::new();
+        ext.info = env_info;
+
+        if let Some(pre) = vm.pre {
+            for (_address, account) in pre.into_iter() {
+                for (k, v) in account.storage {
+                    ext.set_storage(string_2_h256(k), string_2_h256(v))
+                        .expect("Init pre state failed.");
+                }
+            }
+        }
+
+        match evm.exec(&params, &mut ext) {
+            Ok(GasLeft::Known(gas_left)) => assert_eq!(gas_left, string_2_u256(vm.gas.unwrap())),
+            Ok(GasLeft::NeedsReturn { gas_left, data, .. }) => {
+                assert_eq!(gas_left, string_2_u256(vm.gas.unwrap()));
+                assert_eq!((*data).to_vec(), string_2_bytes(vm.out.unwrap()));
+            }
+            Err(_) => assert!(vm.gas.is_none() && vm.post.is_none() && vm.logs.is_none()),
+        }
+
+        if let Some(post) = vm.post {
+            for (_address, account) in post.into_iter() {
+                for (k, v) in account.storage {
+                    if let Ok(value) = ext.storage_at(&string_2_h256(k)) {
+                        assert_eq!(value, string_2_h256(v));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn test_json_path(p: &str) {
+    let info = fs::metadata(p).unwrap();
+    if info.is_dir() {
+        for entry in fs::read_dir(p).unwrap() {
+            let entry = entry.unwrap();
+            let p = entry.path();
+            test_json_path(p.to_str().unwrap());
+        }
+    } else {
+        test_json_file(p);
+    }
+}
+
+fn main() {
+    test_json_path(r"./tests/jsondata/VMTests/vmArithmeticTest");
+    test_json_path(r"./tests/jsondata/VMTests/vmBitwiseLogicOperation");
+    test_json_path(r"./tests/jsondata/VMTests/vmBlockInfoTest");
+    test_json_path(r"./tests/jsondata/VMTests/vmEnvironmentalInfo");
+    test_json_path(r"./tests/jsondata/VMTests/vmIOandFlowOperations");
+    test_json_path(r"./tests/jsondata/VMTests/vmLogTest");
+    test_json_path(r"./tests/jsondata/VMTests/vmRandomTest");
+    test_json_path(r"./tests/jsondata/VMTests/vmSha3Test");
+    test_json_path(r"./tests/jsondata/VMTests/vmPushDupSwapTest");
+    test_json_path(r"./tests/jsondata/VMTests/vmSystemOperations");
+    test_json_path(r"./tests/jsondata/VMTests/vmTests");
+}


### PR DESCRIPTION
# CITA VM 兼容性报告

## 测试环境：
CITA： 最新版本

Ethereum Test:  [最新版本](https://github.com/ethereum/tests)

## 指令计价上的区别

2016年， Ethereum 在高度 2,463,000 上进行了一次分叉，对计价做了调整。详情见 [EIP 150: Gas cost changes for IO-heavy operations](http://eips.ethereum.org/EIPS/eip-150)


Instructions | 							CITA |						Parity|
--------------------|------------------------------------------------------------|--------------------------------------------------|
sload_gas     |                                                          50		|	                                        700|
call_gas          |                                                         40          |                                                700|
extcodesize_gas |                                                  20            |                                               700|
extcodecopy_base_gas|                                       20             |                                              700|
balance_gas                    |                                      20              |                                             400|
suicide_gas                      |                                     0                  |                                           5000|
suicide_to_new_account_cost|                            0                  |                                          5000|

不过该变动没有影响到 cita 运行 [VM Tests](https://github.com/ethereum/tests/tree/develop/VMTests)， 因为这份测试代码也是按照分叉前来设计的。

## 测试结果

[VM Tests](https://github.com/ethereum/tests/tree/develop/VMTests) 现有测试全部通过。

## 后记

这个 pr 先**不要**合，有以下两个问题：
1. 部分指令测试，比如 call, balance，在 vm 测试部分没有覆盖到，需要把 [State Tests](https://github.com/ethereum/tests/tree/develop/GeneralStateTests) 的测试一起集成进来，这样才有保障。
2. 现在我们用的是以太坊官方的测试，是不是要 fork 出来一份。

总体来讲，目前 cita 内嵌的 evm 和我们开发的新vm兼容性问题不大。比较难的可能在 state 那边。

#### Applicable Issues
#365 
