### PR TITLE
Patch to absolute paths' in starting scripts.

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-SOURCE_DIR="$(cd $(dirname "$0") && pwd -P)"
+if [ `uname` == 'Darwin' ]; then
+    SOURCE_DIR="$(dirname $(realpath $0))"
+else
+    SOURCE_DIR="$(dirname $(readlink -f $0))"
+fi
 
 test -f "${SOURCE_DIR}/CODE_OF_CONDUCT.md"
 if [ $? -eq 0 ]; then

--- a/scripts/cita
+++ b/scripts/cita
@@ -3,7 +3,11 @@
 # ex: ts=4 sw=4 et
 
 # Commands Paths
-CITA_BIN="$(cd $(dirname "$0") && pwd -P)"
+if [ `uname` == 'Darwin' ]; then
+    CITA_BIN="$(dirname $(realpath $0))"
+else
+    CITA_BIN="$(dirname $(readlink -f $0))"
+fi
 CITA_SCRIPTS="$(dirname $CITA_BIN)/scripts"
 
 if [ "$1" != "bebop" ]; then


### PR DESCRIPTION
1. `pwd -P` can not handle symlinks in `/usr/local/bin`, support [global usage][1].
2. `DOCKER_CARGO` links a wrong path...XD
3. Slim `INIT_CMD` into a simple string, remove one line empty. #393 

[1]: https://github.com/cryptape/homebrew-cita/pull/1