### PR TITLE
Redirect the stdout and stderr for daemon processes in docker.

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -76,7 +76,7 @@ test -t 1 && USE_TTY="-t"
 # Condition `daemon` to run daemon.
 if [ "$3" == "--daemon"  ]; then
     set "${@:1:2}" "${@:4}"
-    docker exec -d ${CONTAINER_NAME} /usr/bin/gosu ${USER_NAME} "$@"
+    docker exec -d ${CONTAINER_NAME} /bin/bash -c "/usr/bin/gosu ${USER_NAME} $* >/dev/null 2>&1"
 elif [ $# -gt 0 ]; then
     docker exec -i ${USE_TTY} ${CONTAINER_NAME} /usr/bin/gosu ${USER_NAME} "$@"
 else


### PR DESCRIPTION
### Summary

Fix: `docker exec -it` will hang if there is any daemon process which hold the `stdout` (#385).
(I find a issue about this: [moby/issue-33039](https://github.com/moby/moby/issues/33039#issuecomment-353250651))

### Further

This is a temporary solution, I think we should run a script in docker, instead of passing a shell command.

### Additional Knowledge: `"$@"` and `$*`

I think it's too difficult to explain this obscure concept.
So, I write a simple example to show it:

```bash
#!/usr/bin/env bash

function test_dollar () {
    echo "    Total: $# parameters(\$#)"
    echo "        parameter(\$0) = <$0>"
    local i=1
    while [ $# -ne 0 ]; do
        echo "        parameter(\$$i) = <$1>"
        shift 1
        i=$((i+1))
    done
}

echo "Print in function for \$@:"
test_dollar $@
echo "Print in function for \"\$@\":"
test_dollar "$@"
echo "Print in function for \"x y z \$@\":"
test_dollar "x y z $@"
echo "Print in function for \$*:"
test_dollar $*
echo "Print in function for \"\$*\":"
test_dollar "$*"
```

Run it and read the outputs. Have fun!

#### Explanation

Run `./dollar 1 "2 3" 4`:

- `$@` will split parameters by `$IFS` ([Internal Field Separator]), `"2 3"` will be consider as `2` and `3`, so output is:
  > Print in function for $@:
  >     Total: 4 parameters($#)
  >         parameter($0) = <./dollar>
  >         parameter($1) = <1>
  >         parameter($2) = <2>
  >         parameter($3) = <3>
  >         parameter($4) = <4>
- `"$@"` will split parameters as input, so output is:
  > Print in function for "$@":
  >     Total: 3 parameters($#)
  >         parameter($0) = <./dollar>
  >         parameter($1) = <1>
  >         parameter($2) = <2 3>
  >         parameter($3) = <4>
- `"x y z $@"` will do same things as `"$@"`, but `"x y z "` will be consider as prefix of the first parameter (in this example, `"1"` will be consider as `"x y z 1"`), so output is:
  > Print in function for "x y z $@":
  >     Total: 3 parameters($#)
  >         parameter($0) = <./dollar>
  >         parameter($1) = <x y z 1>
  >         parameter($2) = <2 3>
  >         parameter($3) = <4>
- `$*` is same as `$@`, so output is:
  > Print in function for $*:
  >     Total: 4 parameters($#)
  >         parameter($0) = <./dollar>
  >         parameter($1) = <1>
  >         parameter($2) = <2>
  >         parameter($3) = <3>
  >         parameter($4) = <4>
- `"$*"` will consider all inputs as a string, so output is: 
  > Print in function for "$*":
  >     Total: 1 parameters($#)
  >         parameter($0) = <./dollar>
  >         parameter($1) = <1 2 3 4>

So, in this PR, we have to use `$*` in `""`.

If we use `$@` as follow:

```bash
docker exec -d ${CONTAINER_NAME} /bin/bash -c "/usr/bin/gosu ${USER_NAME} $@ >/dev/null 2>&1"
```

When `$@` is `bin/cita start dev-chain/0`

The command will be parsed into 3 parts by shell: `"/usr/bin/gosu ${USER_NAME} bin/cita"`, `start` and `dev-chain/0`.
Actually, it should be 5 parts: `/usr/bin/gosu`, `${USER_NAME}`, `bin/cita`, `start` and `dev-chain/0`.

[Internal Field Separator]: https://en.wikipedia.org/wiki/Internal_field_separator