### PR TITLE
Typo fixed in cita_config.sh.

### DIFF
--- a/scripts/cita_config.sh
+++ b/scripts/cita_config.sh
@@ -9,3 +9,4 @@ if [ -e $CITA_SCRIPTS/create_cita_config.py ]; then
     $CITA_SCRIPTS/create_cita_config.py $@
 else
     echo -e "\033[0;31mPlease run this command after build 🎨"
+fi


### PR DESCRIPTION
## Typo
I found some typos in my previous pr, this pr contains three commits:

#### 1. [d4d1218]Fix config tools' typo.
This commit fixed the `config_tools.sh` —— an `fi` had been forgotten.

~~#### 2. [0fd5651]Adjusting format in env.sh.~~
This commit just optimize the format in `env.sh`, deletes some repeat lines.

~~#### 3. [8ca364b]Remove cargo files in docker container.~~
I'm not sure about this commit, docker volume invoked two wrong variables(This is my fault):
+ first time I try to replace them to the right variables. 
+ then I find, that If cargo files in docker can be removed directly?