### PR TITLE
Fix: getLogs break down the chain when toBlock very large.

### DIFF
--- a/cita-chain/core/src/libchain/chain.rs
+++ b/cita-chain/core/src/libchain/chain.rs
@@ -1187,8 +1187,15 @@ impl Chain {
         from_block: BlockId,
         to_block: BlockId,
     ) -> Option<Vec<BlockNumber>> {
-        match (self.block_number(from_block), self.block_number(to_block)) {
-            (Some(from), Some(to)) => Some(self.blocks_with_bloom(bloom, from, to)),
+        match (
+            self.block_number(from_block),
+            self.block_number(to_block),
+            self.block_number(BlockId::Pending),
+        ) {
+            (Some(from), Some(to), Some(pending)) => {
+                let end = if to > pending { pending } else { to };
+                Some(self.blocks_with_bloom(bloom, from, end))
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
Fix: getLogs break down the chain when toBlock very large.

```rust
let end_block = if to_block > pending_block { pending_block } else { to_block };
```

Issue:
#494 
