### PR TITLE
eliminate warnings

### DIFF
--- a/scripts/config_tool/create_genesis.py
+++ b/scripts/config_tool/create_genesis.py
@@ -120,7 +120,7 @@ class GenesisData(object):
     def load_contracts_list(self, contracts_list_file):
         """From file to load the list of contracts."""
         with open(contracts_list_file, 'r') as stream:
-            contracts_list = yaml.load(stream)
+            contracts_list = yaml.safe_load(stream)
         contracts_list['NormalContracts'] = dictlist_to_ordereddict(
             contracts_list['NormalContracts'])
         contracts_list['PermissionContracts']['basic'] \
@@ -134,7 +134,7 @@ class GenesisData(object):
     def load_contracts_args(self, init_data_file):
         """From file to load arguments for contracts."""
         with open(init_data_file, 'r') as stream:
-            data = yaml.load(stream)
+            data = yaml.safe_load(stream)
         contracts_args = dictlist_to_ordereddict(data['Contracts'])
         for name, arguments in contracts_args.items():
             contracts_args[name] = dictlist_to_ordereddict(arguments)
@@ -305,7 +305,7 @@ def core(contracts_dir, contracts_docs_dir, init_data_file, output, timestamp,
         prevhash,
     )
     with open(init_data_file, 'r') as stream:
-        data = yaml.load(stream)
+        data = yaml.safe_load(stream)
     address = data['Contracts'][2]['NodeManager'][0]['nodes']
     super_admin = data['Contracts'][6]['Admin'][0]['admin']
     address.append(super_admin)

--- a/scripts/config_tool/create_init_data.py
+++ b/scripts/config_tool/create_init_data.py
@@ -98,7 +98,7 @@ class InitializationData(object):
 
     @classmethod
     def load_from_string(cls, cfg):
-        data = yaml.load(cfg)
+        data = yaml.safe_load(cfg)
         contracts_cfgs = dictlist_to_ordereddict(data['Contracts'])
         for name, arguments in contracts_cfgs.items():
             contracts_cfgs[name] = dictlist_to_ordereddict(arguments)


### PR DESCRIPTION
# Eliminate warnings

```sh
$ bin/cita  create --super_admin "0x4b5ae4567ad5d9fb92bc9afd6a657e6fa13a2523" --nodes "127.0.0.1:4000,127.0.0.1:4001,127.0.0.1:4002,127.0.0.1:4003"
```

Output:
```
/opt/cita/scripts/config_tool/create_init_data.py:101: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  data = yaml.load(cfg)
/opt/cita/scripts/config_tool/create_genesis.py:123: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  contracts_list = yaml.load(stream)
/opt/cita/scripts/config_tool/create_genesis.py:137: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  data = yaml.load(stream)
Initializing chain from provided state
/opt/cita/scripts/config_tool/create_genesis.py:308: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  data = yaml.load(stream)
INFO:cita.block	Block pre-sealed, 2246273 quota used 
INFO:cita.chain	Adding to head head=4c29c1f1
```
### Applicable Issues
#498 
