### PR TITLE
Fix: logrotate output log as a relative path

### DIFF
--- a/scripts/cita
+++ b/scripts/cita
@@ -337,7 +337,7 @@ do_logrotate() {
     sleep 2
     for logfile in ${NODE_LOGS_DIR}/cita-*.log; do
         if [[ ${logs} != *"${logfile}"* ]]; then
-            echo "${logfile}"
+            echo "./${NODE_NAME}/logs/${logfile##*/}"
         fi
     done
 }


### PR DESCRIPTION
issue: #485 

```shell
 $ bin/cita logrotate test-chain/0
./test-chain/0/logs/cita-auth_2019-04-23_20-17-58.log
./test-chain/0/logs/cita-bft_2019-04-23_20-17-58.log
./test-chain/0/logs/cita-chain_2019-04-23_20-17-58.log
./test-chain/0/logs/cita-executor_2019-04-23_20-17-58.log
./test-chain/0/logs/cita-jsonrpc_2019-04-23_20-17-58.log
./test-chain/0/logs/cita-network_2019-04-23_20-17-58.log
```
