### PR TITLE
Feature: let native token configurable.

### DIFF
--- a/scripts/config_tool/create_genesis.py
+++ b/scripts/config_tool/create_genesis.py
@@ -275,6 +275,11 @@ def parse_arguments():
         '--output', required=True, help='Path of the output file.')
     parser.add_argument(
         '--timestamp', type=int, help='Specify a timestamp to use.')
+    parser.add_argument(
+        '--init_token',
+        type=lambda x: hex(int(x,16)),
+        default=hex(int("0xffffffffffffffffffffffffff", 16)),
+        help='Init token for this chain, INIT_TOKEN is a hexadecimal number')
     parser.add_argument('--prevhash', help='Prevhash of genesis.')
     args = parser.parse_args()
     return dict(
@@ -283,6 +288,7 @@ def parse_arguments():
         init_data_file=args.init_data_file,
         output=args.output,
         timestamp=args.timestamp,
+        init_token=args.init_token,
         prevhash=args.prevhash,
     )
 

--- a/scripts/config_tool/create_genesis.py
+++ b/scripts/config_tool/create_genesis.py
@@ -239,13 +239,12 @@ class GenesisData(object):
             self.mine_contract_on_chain_tester(addr, data['bin'] + extra)
 
     def set_account_value(self, address, value):
-        for addr in address:
-            self.accounts[addr] = {
-                'code': '',
-                'storage': {},
-                'nonce': '1',
-                'value': value,
-            }
+        self.accounts[address] = {
+            'code': '',
+            'storage': {},
+            'nonce': '1',
+            'value': value,
+        }
 
     def save_to_file(self, filepath):
         with open(filepath, 'w') as stream:
@@ -289,7 +288,7 @@ def parse_arguments():
 
 
 def core(contracts_dir, contracts_docs_dir, init_data_file, output, timestamp,
-         prevhash):
+         init_token, prevhash):
     # pylint: disable=too-many-arguments
     replaceLogRecord()
     if solidity.get_solidity() is None:
@@ -306,13 +305,10 @@ def core(contracts_dir, contracts_docs_dir, init_data_file, output, timestamp,
     )
     with open(init_data_file, 'r') as stream:
         data = yaml.safe_load(stream)
-    address = data['Contracts'][2]['NodeManager'][0]['nodes']
     super_admin = data['Contracts'][6]['Admin'][0]['admin']
-    address.append(super_admin)
-    value = '0xffffffffffffffffffffffffff'
     genesis_data.init_normal_contracts()
     genesis_data.init_permission_contracts()
-    genesis_data.set_account_value(address, value)
+    genesis_data.set_account_value(super_admin, init_token)
     genesis_data.save_to_file(output)
 
 

--- a/scripts/create_cita_config.py
+++ b/scripts/create_cita_config.py
@@ -238,7 +238,7 @@ class ChainInfo():
         from create_init_data import core as create_init_data
         create_init_data(self.init_data_file, super_admin, contract_arguments)
 
-    def create_genesis(self, timestamp, resource_dir):
+    def create_genesis(self, timestamp, init_token, resource_dir):
         from create_genesis import core as create_genesis
         prevhash = generate_prevhash(resource_dir)
         if resource_dir is not None:
@@ -246,7 +246,7 @@ class ChainInfo():
                             os.path.join(self.configs_dir, 'resource'), False)
         create_genesis(self.contracts_dir, self.contracts_docs_dir,
                        self.init_data_file, self.genesis_path, timestamp,
-                       prevhash)
+                       init_token, prevhash)
 
     def append_node(self, node):
         # For append mode: use the first element to store the new node
@@ -339,7 +339,7 @@ def run_subcmd_create(args, work_dir):
         args, os.path.join(work_dir, 'scripts/contracts'),
         os.path.join(work_dir, 'scripts/config_tool/config_example'))
     info.create_init_data(args.super_admin, args.contract_arguments)
-    info.create_genesis(args.timestamp, args.resource_dir)
+    info.create_genesis(args.timestamp, args.init_token, args.resource_dir)
     info.enable_tls = args.enable_tls
     for node in args.nodes:
         info.append_node(node)
@@ -428,6 +428,12 @@ def parse_arguments():
         '--stdout',
         action='store_true',
         help='Logs will output to stdout')
+
+    pcreate.add_argument(
+        '--init_token',
+        type=lambda x: hex(int(x,16)),
+        default=hex(int("0xffffffffffffffffffffffffff", 16)),
+        help='Init token for this chain, INIT_TOKEN is a hexadecimal number')
 
     #
     # Subcommand: append

--- a/tests/integrate_test/test_charge_mode.py
+++ b/tests/integrate_test/test_charge_mode.py
@@ -126,6 +126,12 @@ def get_miner_with_balance(miner_privkeys):
     raise Exception('Get miner with balance timeout(60)')
 
 
+def transfer_token_to_miner(superadmin_privkey, miner_privkeys, version):
+    for privkey in miner_privkeys:
+        address = key_address(privkey)
+        test_transfer(superadmin_privkey, address, 100000000000000, version)
+
+
 def key_address(privkey):
     """ Get the address of a privkey """
     hash_obj = sha3.keccak_256()
@@ -149,6 +155,10 @@ def main():
     parser.add_argument(
         "--version", help="Tansaction version.", default=1, type=int)
     args = parser.parse_args()
+
+    # Transfers 100000000000000 tokens from super admin to each miner
+    super_privkey = '0x5f0258a4778057a8a7d97809bd209055b2fbafa654ce7d31ec7191066b9225e6'
+    transfer_token_to_miner(super_privkey, args.miner_privkeys, args.version)
 
     miner_privkey = get_miner_with_balance(args.miner_privkeys)
     version = args.version


### PR DESCRIPTION
Let native token configurable:
usage:
```
--init_token INIT_TOKEN
                        Init token for this chain, INIT_TOKEN is a hexadecimal
                        number
```

Example:

```shell
bin/cita bebop --init_token 0x123  --contract_arguments SysConfig.economicalModel=1 --super_admin "0x4b5ae4567ad5d9fb92bc9afd6a657e6fa13a2523" --nodes "127.0.0.1:4000,127.0.0.1:4001,127.0.0.1:4002,127.0.0.1:4003"
```