### PR TITLE
Fix: docker port expose error

### DIFF
--- a/scripts/cita
+++ b/scripts/cita
@@ -78,7 +78,8 @@ This is the primary script for controlling the $SCRIPT node.
         use "cita append -h" to get more information.
         "cita-config" has the same function.
     port <ports>
-        Sets docker port, for example: "cita port 1337:1337"
+        Sets docker port, for example: "cita port 1337:1337 1338:1338",
+        expose docker port 1337 and 1338.
  SERVICE CONTROL COMMANDS
     setup <node>
         Ensuring the required runtime environment for $SCRIPT node, like


### PR DESCRIPTION
Fix: docker port expose error

Expose single ports:
```shell
$ cita port 1338:1338
Expose ports: 1338:1338
Start docker container cita_run_container ...
a5ad8bb52ac61b42ec90274c955756b2c716f2a3b5c9612c89844b0fdf0b1bcf
No such node directory: 1338:1338
```

Should not get the error:
```
No such node directory: 1338:1338
```

Expose multi-ports:
```shell
$ bin/cita port 1338:1338 1337:1337
Expose ports: 1338:1338 1337:1337
Start docker container cita_run_container ...
Unable to find image '1337:1337' locally
docker: Error response from daemon: pull access denied for 1337, repository does not exist or may require 'docker login'.
See 'docker run --help'.
Error: No such container: cita_run_container
```

Should not get the error:
```
Unable to find image '1337:1337' locally
docker: Error response from daemon: pull access denied for 1337, repository does not exist or may require 'docker login'.
```

issue: #515, #517 

**PR Test:**
```shell
$ bin/cita port 1338:1338 1339:1339
Expose ports: 1338:1338 1339:1339
Start docker container cita_run_container ...
2fac3880386221f95608e02d3a6d26dd0dadfa75955a4db092de53406ce3dacc
```
Docker will exit after `cita port` command finished, and check it works by `docker ps`.

```shell
$ docker ps
CONTAINER ID        IMAGE                                   COMMAND                  CREATED             STATUS              PORTS                              NAMES
2fac38803862        cita/cita-run:ubuntu-18.04-20190419     "/usr/bin/entrypoint…"   12 seconds ago      Up 10 seconds       0.0.0.0:1338-1339->1338-1339/tcp   cita_run_container
```