### PR TITLE
Bump rust toolchain to `1.34.1`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ alias:
 
   - &job-default
     docker:
-      - image: cita/cita-build:ubuntu-18.04-20190413
+      - image: cita/cita-build:ubuntu-18.04-20190429
     working_directory: ~/cita-build
     resource_class: xlarge
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ stages:
   - Release
   - IntegrateTest
 before_install:
-  - docker pull cita/cita-build:ubuntu-18.04-20190413
+  - docker pull cita/cita-build:ubuntu-18.04-20190429
 jobs:
   include:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 [[package]]
 name = "authority_manage"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "blake2b"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -518,7 +518,7 @@ dependencies = [
 [[package]]
 name = "cita-crypto"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-ed25519 0.6.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -529,7 +529,7 @@ dependencies = [
 [[package]]
 name = "cita-crypto-trait"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
 ]
@@ -537,7 +537,7 @@ dependencies = [
 [[package]]
 name = "cita-directories"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -545,7 +545,7 @@ dependencies = [
 [[package]]
 name = "cita-ed25519"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "cita-merklehash"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "hashable 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -699,7 +699,7 @@ dependencies = [
 [[package]]
 name = "cita-secp256k1"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -716,7 +716,7 @@ dependencies = [
 [[package]]
 name = "cita-sm2"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -730,7 +730,7 @@ dependencies = [
 [[package]]
 name = "cita-types"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "ethereum-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plain_hasher 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "elastic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1206,7 +1206,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "engine"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "error"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 
 [[package]]
 name = "error-chain"
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "ethcore-bloom-journal"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "siphasher 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1583,7 +1583,7 @@ dependencies = [
 [[package]]
 name = "hashable"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "blake2b 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1767,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "jsonrpc-proto"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1784,7 +1784,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-types"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-types-internals"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1880,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "libproto"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-merklehash 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2036,7 +2036,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2386,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "panic_hook"
 version = "0.0.1"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "pubsub"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pubsub_kafka 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2564,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "pubsub_kafka"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "pubsub_rabbitmq"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "amqp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "pubsub_zeromq"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "crossbeam-channel 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "logger 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "rlp"
 version = "0.2.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2932,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "rlp_derive"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3137,7 +3137,7 @@ dependencies = [
 [[package]]
 name = "snappy"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3819,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "tx_pool"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -3961,7 +3961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "util"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#3ec4e19ca77563c261ba36bc179cac484901bea0"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#49c6929b677b3adc5209f9c69c55f6285ae263d2"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",

--- a/env.sh
+++ b/env.sh
@@ -13,7 +13,7 @@ fi
 
 if test -f "${SOURCE_DIR}/Cargo.toml"; then
     readonly CONTAINER_NAME='cita_build_container'
-    readonly DOCKER_IMAGE='cita/cita-build:ubuntu-18.04-20190413'
+    readonly DOCKER_IMAGE='cita/cita-build:ubuntu-18.04-20190429'
 else
     readonly CONTAINER_NAME='cita_run_container'
     readonly DOCKER_IMAGE='cita/cita-run:ubuntu-18.04-20190419'


### PR DESCRIPTION
### Description of the Change

Rust version [`1.34.1`](https://blog.rust-lang.org/2019/04/25/Rust-1.34.1.html)

