### PR TITLE
Update jubjub to fix zktx. [skip travis]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "jubjub"
 version = "0.0.1"
-source = "git+https://github.com/cryptape/jubjub-prototype.git?branch=modified#91e46fbb689e158a03cb11146f8a124ac27c764d"
+source = "git+https://github.com/cryptape/jubjub-prototype.git?branch=modified#198cb4080f45decc652aa393f2605cb5d9ddbd8b"
 dependencies = [
  "bellman 0.0.4 (git+https://github.com/cryptape/bellman.git?branch=0.0.4_modified)",
  "pairing 0.11.0 (git+https://github.com/cryptape/pairing.git?branch=0.11-release)",
@@ -2536,11 +2536,6 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "protobuf"
-version = "1.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "protobuf"
@@ -4118,17 +4113,14 @@ dependencies = [
 [[package]]
 name = "zktx"
 version = "0.0.1"
-source = "git+https://github.com/cryptape/zktx.git#fe4fcb702c6a6c8bef560a3e3d2ee027fa64ad67"
+source = "git+https://github.com/cryptape/zktx.git#df9371c58296885a780bdf44c270703ffa7ac5e9"
 dependencies = [
  "bellman 0.0.4 (git+https://github.com/cryptape/bellman.git?branch=0.0.4_modified)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jubjub 0.0.1 (git+https://github.com/cryptape/jubjub-prototype.git?branch=modified)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pairing 0.11.0 (git+https://github.com/cryptape/pairing.git?branch=0.11-release)",
- "protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-hex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4382,7 +4374,6 @@ dependencies = [
 "checksum proc-macro2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "77997c53ae6edd6d187fec07ec41b207063b5ee6f33680e9fa86d405cdd313d4"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum proof 0.6.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)" = "<none>"
-"checksum protobuf 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "52fbc45bf6709565e44ef31847eb7407b3c3c80af811ee884a04da071dcca12b"
 "checksum protobuf 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "56c363dfc36e450457f4fa05a91d8c3f0fed00fc21142b4ce2cb7b525675eaeb"
 "checksum pubsub 0.6.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)" = "<none>"
 "checksum pubsub_kafka 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)" = "<none>"


### PR DESCRIPTION
### Description of the Change

* Update `jubjub`
* Update `zktx`

For the error of `cargo run --release --bin client`

preview:

![Screenshot from 2019-05-06 21-22-19](https://user-images.githubusercontent.com/8768261/57227954-2ce88100-7045-11e9-9cf4-f678c1e52e80.png)

### Applicable Issues

https://github.com/cryptape/zktx_example/issues/3