### PR TITLE
Rust 2018 edition for some crates

### DIFF
--- a/cita-auth/Cargo.toml
+++ b/cita-auth/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cita-auth"
 version = "0.1.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
+edition = "2018"
 
 [dependencies]
 clap = "2"

--- a/cita-auth/src/block_txn.rs
+++ b/cita-auth/src/block_txn.rs
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::handler::verify_tx_sig;
+use crate::hashable::Hashable;
 use cita_types::H256;
-use handler::verify_tx_sig;
-use hashable::Hashable;
 use libproto::TryInto;
 use libproto::{BlockTxn, GetBlockTxn, Origin, SignedTransaction};
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};

--- a/cita-auth/src/dispatcher.rs
+++ b/cita-auth/src/dispatcher.rs
@@ -15,9 +15,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+use crate::handler::SysConfigInfo;
+use crate::txwal::TxWal;
 use cita_types::traits::LowerHex;
 use cita_types::{Address, H256};
-use handler::SysConfigInfo;
 use libproto::blockchain::{AccountGasLimit, BlockBody, BlockTxs, SignedTransaction};
 use libproto::router::{MsgType, RoutingKey, SubModules};
 use libproto::Message;
@@ -28,7 +29,6 @@ use std::collections::HashSet;
 use std::convert::Into;
 use std::thread;
 use tx_pool;
-use txwal::TxWal;
 
 pub struct Dispatcher {
     txs_pool: RefCell<tx_pool::Pool>,

--- a/cita-auth/src/handler.rs
+++ b/cita-auth/src/handler.rs
@@ -15,14 +15,15 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use block_txn::{BlockTxnMessage, BlockTxnReq};
-use block_verify::BlockVerify;
+use crate::block_txn::{BlockTxnMessage, BlockTxnReq};
+use crate::block_verify::BlockVerify;
+use crate::dispatcher::Dispatcher;
+use crate::history::HistoryHeights;
+use crate::transaction_verify::Error;
 use cita_types::traits::LowerHex;
 use cita_types::{clean_0x, Address, H256, U256};
 use crypto::{pubkey_to_address, PubKey, Sign, Signature, SIGNATURE_BYTES_LEN};
-use dispatcher::Dispatcher;
 use error::ErrorCode;
-use history::HistoryHeights;
 use jsonrpc_types::rpc_types::TxResponse;
 use libproto::auth::{Miscellaneous, MiscellaneousReq};
 use libproto::blockchain::{AccountGasLimit, SignedTransaction};
@@ -42,7 +43,6 @@ use std::collections::{HashMap, HashSet};
 use std::convert::Into;
 use std::str::FromStr;
 use std::time::Duration;
-use transaction_verify::Error;
 use util::BLOCKLIMIT;
 
 const TX_OK: &str = "OK";

--- a/cita-auth/src/main.rs
+++ b/cita-auth/src/main.rs
@@ -69,35 +69,22 @@
 //!
 
 extern crate cita_crypto as crypto;
-extern crate cita_directories;
-extern crate cita_types;
-extern crate clap;
 extern crate core as chain_core;
-extern crate cpuprofiler;
-extern crate dotenv;
-extern crate error;
-extern crate jsonrpc_types;
 #[macro_use]
 extern crate libproto;
 #[macro_use]
 extern crate cita_logger as logger;
-extern crate lru;
-extern crate pubsub;
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
-extern crate rayon;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_json;
 #[cfg(test)]
 extern crate tempfile;
-extern crate tx_pool;
 #[macro_use]
 extern crate util;
 extern crate db as cita_db;
 extern crate hashable;
-extern crate uuid;
 
 use batch_forward::BatchForward;
 use clap::App;

--- a/tools/create_key_addr/Cargo.toml
+++ b/tools/create_key_addr/Cargo.toml
@@ -2,6 +2,7 @@
 name = "create_key_addr"
 version = "0.1.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
+edition = "2018"
 
 [dependencies]
 cita-crypto = { git = "https://github.com/cryptape/cita-common.git", branch = "develop" }

--- a/tools/create_key_addr/src/main.rs
+++ b/tools/create_key_addr/src/main.rs
@@ -1,5 +1,5 @@
 // CITA
-// Copyright 2016-2017 Cryptape Technologies LLC.
+// Copyright 2016-2019 Cryptape Technologies LLC.
 
 // This program is free software: you can redistribute it
 // and/or modify it under the terms of the GNU General Public
@@ -16,9 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 extern crate cita_crypto as crypto;
-extern crate hashable;
 
-use crypto::{CreateKey, KeyPair, PubKey};
+use crate::crypto::{CreateKey, KeyPair, PubKey};
 use hashable::Hashable;
 use std::env;
 use std::fs::{File, OpenOptions};

--- a/tools/snapshot_tool/Cargo.toml
+++ b/tools/snapshot_tool/Cargo.toml
@@ -2,6 +2,7 @@
 name = "snapshot_tool"
 version = "0.2.0"
 authors = ["Cryptape Technologies <contact@cryptape.com>"]
+edition = "2018"
 
 [dependencies]
 dotenv = "0.13.0"

--- a/tools/snapshot_tool/src/main.rs
+++ b/tools/snapshot_tool/src/main.rs
@@ -15,22 +15,17 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate clap;
-extern crate dotenv;
-extern crate error;
-extern crate fs2;
 #[macro_use]
 extern crate libproto;
 #[macro_use]
 extern crate cita_logger as logger;
-extern crate pubsub;
 #[macro_use]
 extern crate util;
 
+use crate::postman::Postman;
 use clap::App;
 use fs2::FileExt;
 use libproto::router::{MsgType, RoutingKey, SubModules};
-use postman::Postman;
 use pubsub::channel;
 use pubsub::start_pubsub;
 use std::fs::{self, File, OpenOptions};


### PR DESCRIPTION
### Description of the Change

cita-auth, create_key_addr and snapshot_tool

* `cargo fix --edition`
* remove useless `extern`

### Applicable Issues

#607 