### PR TITLE
Fix: should not use error message in default auto exec.

### DIFF
--- a/cita-executor/core/src/contracts/solc/sys_config.rs
+++ b/cita-executor/core/src/contracts/solc/sys_config.rs
@@ -341,7 +341,7 @@ impl<'a> SysConfig<'a> {
     }
 
     pub fn default_auto_exec() -> bool {
-        error!("Use the default autoEXEC.");
+        info!("Use the default autoEXEC.");
         false
     }
 }


### PR DESCRIPTION
Should not use error message in default auto exec.

The function `conf.auto_exec` will run each block, the `Error`  message will confuse to our users.

```
2019-06-11T12:57:07.394285300+00:00 - ERROR - Use the default autoEXEC.
2019-06-11T12:57:08.926864406+00:00 - INFO - executor init, current_height: 3724098, current_hash: 0x8d5abdbaab8469a1af27402e2f44026da6a21dac5f98131e475a4b6cd4df0ea0
2019-06-11T12:57:08.934952743+00:00 - INFO - Use default quota price
2019-06-11T12:57:08.948182035+00:00 - INFO - Use default auto exec quota limit.
2019-06-11T12:57:08.970409072+00:00 - ERROR - Use the default autoEXEC.
2019-06-11T12:57:09.749927095+00:00 - INFO - Use default quota price
2019-06-11T12:57:09.757813566+00:00 - INFO - Use default auto exec quota limit.
2019-06-11T12:57:09.773810266+00:00 - ERROR - Use the default autoEXEC.
```
