### PR TITLE
Fix compiler error

### DIFF
--- a/cita-chain/types/src/basic_types.rs
+++ b/cita-chain/types/src/basic_types.rs
@@ -21,7 +21,7 @@ pub use crate::log_entry::LogBloom;
 
 pub use crate::log_blooms::LogBloomGroup;
 
-/// Constant 2048-bit datum for 0. Often used as a default.
+// Constant 2048-bit datum for 0. Often used as a default.
 lazy_static! {
     pub static ref ZERO_LOGBLOOM: LogBloom = LogBloom::from([0x00; 256]);
 }

--- a/cita-jsonrpc/src/fdlimit.rs
+++ b/cita-jsonrpc/src/fdlimit.rs
@@ -17,7 +17,6 @@
 
 #[cfg(any(target_os = "linux"))]
 pub fn set_fd_limit() {
-    use libc;
     use std::io;
 
     unsafe {


### PR DESCRIPTION
### Description of the Change

There are two compiler error happened, when type `make debug`:

* Fix rustdoc check
```
error: unused doc comment
  --> cita-chain/types/src/basic_types.rs:24:1
   |
24 |   /// Constant 2048-bit datum for 0. Often used as a default.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
25 | / lazy_static! {
26 | |     pub static ref ZERO_LOGBLOOM: LogBloom = LogBloom::from([0x00; 256]);
27 | | }
   | |_- rustdoc does not generate documentation for macro expansions
   |
   = note: `-F unused-doc-comments` implied by `-F warnings`
   = help: to document an item produced by a macro, the macro must produce the documentation as part of its expansion
```

* Fix compiler error

```
error: the item `libc` is imported redundantly
  --> cita-jsonrpc/src/fdlimit.rs:20:9
   |
20 |     use libc;
   |         ^^^^
   |
   = note: `-F unused-imports` implied by `-F warnings`

```

### Environment
Os: Ubuntu 18.04
Rustc: rustc 1.36.0 (a53f9df32 2019-07-03)