### PR TITLE
Account start nonce

### DIFF
--- a/cita-executor/core/src/libexecutor/block.rs
+++ b/cita-executor/core/src/libexecutor/block.rs
@@ -88,7 +88,7 @@ impl ExecutedBlock {
         last_hashes: Arc<LastHashes>,
         eth_compatibility: bool,
     ) -> Result<Self, Error> {
-        let state = State::from_existing(db, state_root, U256::default(), factories)?;
+        let state = State::from_existing(db, state_root, factories)?;
 
         let r = ExecutedBlock {
             block,

--- a/cita-executor/core/src/libexecutor/command.rs
+++ b/cita-executor/core/src/libexecutor/command.rs
@@ -210,7 +210,7 @@ impl Commander for Executor {
     /// Generate block's final state.
     fn gen_state(&self, root: H256, parent_hash: H256) -> Option<State<StateDB>> {
         let db = self.state_db.read().boxed_clone_canon(&parent_hash);
-        State::from_existing(db, root, U256::from(0), self.factories.clone()).ok()
+        State::from_existing(db, root, self.factories.clone()).ok()
     }
 
     /// Get code by address

--- a/cita-executor/core/src/libexecutor/genesis.rs
+++ b/cita-executor/core/src/libexecutor/genesis.rs
@@ -112,7 +112,6 @@ impl Genesis {
         let mut state = State::from_existing(
             state_db.boxed_clone_canon(&self.spec.prevhash),
             *self.block.state_root(),
-            U256::from(0),
             factories.clone(),
         )
         .expect("state db error");

--- a/tests/json-test/src/helper.rs
+++ b/tests/json-test/src/helper.rs
@@ -57,7 +57,7 @@ pub fn secret_2_address(secret: &str) -> Address {
 
 pub fn get_temp_state() -> State<StateDB> {
     let state_db = get_temp_state_db();
-    State::new(state_db, 0.into(), Default::default())
+    State::new(state_db, Default::default())
 }
 
 pub fn new_db() -> Arc<KeyValueDB> {

--- a/tools/create-genesis/src/common.rs
+++ b/tools/create-genesis/src/common.rs
@@ -45,7 +45,7 @@ pub fn secret_2_address(secret: &str) -> Address {
 
 pub fn get_temp_state() -> State<StateDB> {
     let state_db = get_temp_state_db();
-    State::new(state_db, 0.into(), Default::default())
+    State::new(state_db, Default::default())
 }
 
 pub fn new_db() -> Arc<KeyValueDB> {


### PR DESCRIPTION
### Description of the Change

The default `account start nonce` is 0. Replace `account start nonce` in State structure with 0 to make 

core state structure more simpler. 

