### PR TITLE
Fix: Update permission's cache error.

### DIFF
--- a/cita-executor/core/src/authentication.rs
+++ b/cita-executor/core/src/authentication.rs
@@ -111,7 +111,11 @@ fn check_send_tx(
         &func[..],
     );
 
-    trace!("has send tx permission: {:?}", has_permission);
+    trace!(
+        "Account {:?} has send tx permission: {:?}",
+        account,
+        has_permission
+    );
 
     if !has_permission {
         return Err(AuthenticationError::NoTransactionPermission);

--- a/cita-executor/core/src/benches/executor.rs
+++ b/cita-executor/core/src/benches/executor.rs
@@ -71,7 +71,8 @@ fn test_block_with_10000_tx_write_db(b: &mut Bencher) {
     let block = generate_block(&executor, 10000);
 
     b.iter(|| {
-        let closed_block = executor.into_fsm(block.clone());
-        executor.grow(closed_block);
+        let mut closed_block = executor.into_fsm(block.clone());
+        executor.grow(&closed_block);
+        closed_block.clear_cache();
     });
 }

--- a/cita-executor/core/src/libexecutor/executor.rs
+++ b/cita-executor/core/src/libexecutor/executor.rs
@@ -198,7 +198,7 @@ impl Executor {
     /// 1. Header
     /// 2. CurrentHash
     /// 3. State
-    pub fn write_batch(&self, block: ClosedBlock) {
+    pub fn write_batch(&self, block: &ClosedBlock) {
         let height = block.number();
         let hash = block.hash().unwrap();
         let version = block.version();
@@ -514,8 +514,9 @@ mod tests {
         let data = helpers::generate_contract();
         for _i in 0..5 {
             let block = helpers::create_block(&executor, Address::from(0), &data, (0, 1), &privkey);
-            let closed_block = executor.into_fsm(block.clone());
-            executor.grow(closed_block);
+            let mut closed_block = executor.into_fsm(block.clone());
+            executor.grow(&closed_block);
+            closed_block.clear_cache();
         }
 
         let current_height = executor.get_current_height();
@@ -543,10 +544,11 @@ mod tests {
 
         let data = helpers::generate_contract();
         let block = helpers::create_block(&executor, Address::from(0), &data, (0, 1), &privkey);
-        let closed_block = executor.into_fsm(block.clone());
+        let mut closed_block = executor.into_fsm(block.clone());
         let closed_block_height = closed_block.number();
         let closed_block_hash = closed_block.hash();
-        executor.grow(closed_block);
+        executor.grow(&closed_block);
+        closed_block.clear_cache();
 
         let current_height = executor.get_current_height();
         let current_hash = executor.block_hash(current_height);


### PR DESCRIPTION
Fix: Update permission's cache error.

Self test:

```shell
cita> scm PermissionManagement setAuthorizations --permissions '[ffffffffffffffffffffffffffffffffff021000]' --account 0xf4b92dca1461dab977521c07aa9dc055d4e0715b --private-key 0x5f0258a4778057a8a7d97809bd209055b2fbafa654ce7d31ec7191066b9225e6
{
  "id": 4,
  "jsonrpc": "2.0",
  "result": {
    "hash": "0x7f9f81e57f8baa89dcc8a1c0d289b4695e9ecdfa35b41f65810f759ded07b1ed",
    "status": "OK"
  }
}

cita> scm Authorization checkPermission --account 0xf4b92dca1461dab977521c07aa9dc055d4e0715b --permission 0xffffffffffffffffffffffffffffffffff021000
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "0x0000000000000000000000000000000000000000000000000000000000000001"
}

cita> transfer --address 0xf4b92dca1461dab977521c07aa9dc055d4e0715b --value 1000000000 --private-key 0x5f0258a4778057a8a7d97809bd209055b2fbafa654ce7d31ec7191066b9225e6
{
  "id": 4,
  "jsonrpc": "2.0",
  "result": {
    "hash": "0x428db621c24043a50f925808b6dde368a2c0afd57704f1a7b4620931566f5cf3",
    "status": "OK"
  }
}

cita> rpc getBalance --address 0xf4b92dca1461dab977521c07aa9dc055d4e0715b
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "0x3b9aca00"
}

cita> transfer --address 0xdb498db53cda22283a2341cedb250aa18421e0d8 --private-key 0xd9a29f28ae6b80d566a3320654328688b114bba9390a17dafe0397a7e6dca4a5 --value 100
{
  "id": 4,
  "jsonrpc": "2.0",
  "result": {
    "hash": "0xe74e877d0b75ddee3117a746039c790311c00099311c4b8a2c2025e8394da567",
    "status": "OK"
  }
}

cita> rpc getBalance --address 0xdb498db53cda22283a2341cedb250aa18421e0d8
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "0x64"
}
```