### PR TITLE
refactor errors in chain and executor 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,6 +855,7 @@ dependencies = [
  "cita-ed25519 0.6.0 (git+https://github.com/cryptape/cita-common.git?branch=remove-gpl)",
  "cita-logger 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=remove-gpl)",
+ "cita-vm 0.2.1 (git+https://github.com/cryptape/cita-vm.git?branch=cita)",
  "cita_trie 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashable 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=remove-gpl)",
  "jsonrpc-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=remove-gpl)",

--- a/cita-chain/types/Cargo.toml
+++ b/cita-chain/types/Cargo.toml
@@ -25,6 +25,7 @@ cita_trie = "2.0.0"
 cita-logger = "0.1.0"
 proof = { git = "https://github.com/cryptape/cita-common.git", branch = "remove-gpl" }
 cita-database = { git = "https://github.com/cryptape/cita-database.git", branch = "develop" }
+cita-vm = { git = "https://github.com/cryptape/cita-vm.git", branch = "cita" }
 
 [features]
 default = ["secp256k1", "sha3hash"]

--- a/cita-chain/types/src/errors/authentication.rs
+++ b/cita-chain/types/src/errors/authentication.rs
@@ -1,0 +1,21 @@
+use std::fmt;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum AuthenticationError {
+    NoTransactionPermission,
+    NoContractPermission,
+    NoCallPermission,
+    InvalidTransaction,
+}
+
+impl fmt::Display for AuthenticationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match *self {
+            AuthenticationError::NoTransactionPermission => "No transaction permission.".to_owned(),
+            AuthenticationError::NoContractPermission => "No create contract permision.".to_owned(),
+            AuthenticationError::NoCallPermission => "No contract call permission.".to_owned(),
+            AuthenticationError::InvalidTransaction => "Invalid transaction.".to_owned(),
+        };
+        write!(f, "{}", printable)
+    }
+}

--- a/cita-chain/types/src/errors/call.rs
+++ b/cita-chain/types/src/errors/call.rs
@@ -1,0 +1,32 @@
+use super::execution::ExecutionError;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum CallError {
+    /// Couldn't find the transaction in the chain.
+    TransactionNotFound,
+    /// Couldn't find requested block's state in the chain.
+    StatePruned,
+    /// Couldn't find an amount of gas that didn't result in an exception.
+    Exceptional,
+    /// Corrupt state.
+    StateCorrupt,
+    /// Error executing.
+    Execution(ExecutionError),
+}
+
+impl fmt::Display for CallError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use self::CallError::*;
+
+        let msg = match *self {
+            TransactionNotFound => "Transaction couldn't be found in the chain".into(),
+            StatePruned => "Couldn't find the transaction block's state in the chain".into(),
+            Exceptional => "An exception happened in the execution".into(),
+            StateCorrupt => "Stored state found to be corrupted.".into(),
+            Execution(ref e) => format!("{}", e),
+        };
+
+        f.write_fmt(format_args!("Transaction execution error ({}).", msg))
+    }
+}

--- a/cita-chain/types/src/errors/execution.rs
+++ b/cita-chain/types/src/errors/execution.rs
@@ -1,100 +1,62 @@
-// Copyright 2015-2017 Parity Technologies (UK) Ltd.
-// This file is part of Parity.
-
-// This software is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-
-// This software is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
-
-//! General error types for use in ethcore.
-
 use std::fmt;
 
-use cita_types::{U256, U512};
+use super::authentication::AuthenticationError;
+use super::call::CallError;
+use super::native::NativeError;
+use cita_vm::state::Error as StateError;
 
-/// Result of executing the transaction.
-#[derive(PartialEq, Debug, Clone)]
-#[cfg_attr(feature = "ipc", binary)]
+#[derive(Debug)]
 pub enum ExecutionError {
-    /// Returned when there gas paid for transaction execution is
-    /// lower than base gas required.
-    NotEnoughBaseGas {
-        /// Absolute minimum gas required.
-        required: U256,
-        /// Gas provided.
-        got: U256,
-    },
-    /// Returned when block (quota_used + gas) > quota_limit.
-    ///
-    /// If gas =< quota_limit, upstream may try to execute the transaction
-    /// in next block.
-    BlockGasLimitReached {
-        /// Gas limit of block for transaction.
-        quota_limit: U256,
-        /// Gas used in block prior to transaction.
-        quota_used: U256,
-        /// Amount of gas in block.
-        gas: U256,
-    },
-    AccountGasLimitReached {
-        /// Account Gas limit left
-        quota_limit: U256,
-        /// Amount of gas in transaction
-        gas: U256,
-    },
-    /// Returned when transaction nonce does not match state nonce.
-    InvalidNonce {
-        /// Nonce expected.
-        expected: U256,
-        /// Nonce found.
-        got: U256,
-    },
-    /// Returned when cost of transaction (value + gas_price * gas) exceeds
-    /// current sender balance.
-    NotEnoughCash {
-        /// Minimum required balance.
-        required: U512,
-        /// Actual balance.
-        got: U512,
-    },
-    NoTransactionPermission,
-    NoContractPermission,
-    NoCallPermission,
-    /// Returned when internal evm error occurs.
-    ExecutionInternal(String),
-    /// Returned when generic transaction occurs
-    TransactionMalformed(String),
+    Internal(String),
+    Authentication(AuthenticationError),
+    InvalidTransaction,
+    NotEnoughBaseGas,
+    InvalidNonce,
+    NotEnoughBalance,
+    BlockQuotaLimitReached,
+    AccountQuotaLimitReached,
 }
+
+impl std::error::Error for ExecutionError {}
 
 impl fmt::Display for ExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ExecutionError::*;
-
-        let msg = match *self {
-            NotEnoughBaseGas { ref required, ref got } => format!("Not enough base quota. {} is required, but only {} paid", required, got),
-            BlockGasLimitReached {
-                ref quota_limit,
-                ref quota_used,
-                ref gas,
-            } => format!("Block gas limit reached. The limit is {}, {} has already been used, and {} more is required", quota_limit, quota_used, gas),
-            AccountGasLimitReached { ref quota_limit, ref gas } => format!("Account gas limit reached. The limit is {}, {} more is required", quota_limit, gas),
-            InvalidNonce { ref expected, ref got } => format!("Invalid transaction nonce: expected {}, found {}", expected, got),
-            NotEnoughCash { ref required, ref got } => format!("Cost of transaction exceeds sender balance. {} is required but the sender only has {}", required, got),
-            ExecutionInternal(ref msg) => msg.clone(),
-            TransactionMalformed(ref err) => format!("Malformed transaction: {}", err),
-            NoTransactionPermission => "No transaction permission".to_owned(),
-            NoContractPermission => "No contract permission".to_owned(),
-            NoCallPermission => "No call contract permission".to_owned(),
+        let printable = match *self {
+            ExecutionError::Internal(ref err) => format!("internal error: {:?}", err),
+            ExecutionError::Authentication(ref err) => format!("internal error: {:?}", err),
+            ExecutionError::InvalidTransaction => "invalid transaction".to_owned(),
+            ExecutionError::NotEnoughBaseGas => "not enough base gas".to_owned(),
+            ExecutionError::InvalidNonce => "invalid nonce".to_owned(),
+            ExecutionError::NotEnoughBalance => "not enough balance".to_owned(),
+            ExecutionError::BlockQuotaLimitReached => "block quota limit reached".to_owned(),
+            ExecutionError::AccountQuotaLimitReached => "account quota limit reached".to_owned(),
         };
+        write!(f, "{}", printable)
+    }
+}
 
-        f.write_fmt(format_args!("Transaction execution error ({}).", msg))
+impl From<NativeError> for ExecutionError {
+    fn from(err: NativeError) -> Self {
+        match err {
+            NativeError::Internal(err_str) => ExecutionError::Internal(err_str),
+        }
+    }
+}
+
+impl From<AuthenticationError> for ExecutionError {
+    fn from(err: AuthenticationError) -> Self {
+        ExecutionError::Authentication(err)
+    }
+}
+
+impl From<StateError> for ExecutionError {
+    fn from(err: StateError) -> Self {
+        ExecutionError::Internal(format!("{}", err))
+    }
+}
+
+impl From<ExecutionError> for CallError {
+    fn from(error: ExecutionError) -> Self {
+        CallError::Execution(error)
     }
 }

--- a/cita-chain/types/src/errors/mod.rs
+++ b/cita-chain/types/src/errors/mod.rs
@@ -1,13 +1,22 @@
+mod authentication;
+mod call;
 mod execution;
+mod native;
 mod receipt;
 
+pub use authentication::AuthenticationError;
+pub use call::CallError;
 pub use execution::ExecutionError;
+pub use native::NativeError;
 pub use receipt::ReceiptError;
 
 #[derive(Debug)]
 pub enum Error {
     Execution(ExecutionError),
     Receipt(ReceiptError),
+    Call(CallError),
+    Native(NativeError),
+    Authentication(AuthenticationError),
 }
 
 impl std::fmt::Display for Error {
@@ -15,6 +24,9 @@ impl std::fmt::Display for Error {
         let err = match self {
             Error::Execution(ref err) => format!("Execution error {:?}", err),
             Error::Receipt(ref err) => format!("Receipt error {:?}", err),
+            Error::Call(ref err) => format!("Call error {:?}", err),
+            Error::Native(ref err) => format!("Native error {:?}", err),
+            Error::Authentication(ref err) => format!("Authentication error {:?}", err),
         };
         write!(f, "{}", err)
     }
@@ -29,5 +41,20 @@ impl From<ExecutionError> for Error {
 impl From<ReceiptError> for Error {
     fn from(err: ReceiptError) -> Error {
         Error::Receipt(err)
+    }
+}
+impl From<CallError> for Error {
+    fn from(err: CallError) -> Error {
+        Error::Call(err)
+    }
+}
+impl From<NativeError> for Error {
+    fn from(err: NativeError) -> Error {
+        Error::Native(err)
+    }
+}
+impl From<AuthenticationError> for Error {
+    fn from(err: AuthenticationError) -> Error {
+        Error::Authentication(err)
     }
 }

--- a/cita-chain/types/src/errors/native.rs
+++ b/cita-chain/types/src/errors/native.rs
@@ -1,0 +1,15 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum NativeError {
+    Internal(String),
+}
+
+impl fmt::Display for NativeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match self {
+            NativeError::Internal(str) => format!("Internal error {:?}", str),
+        };
+        write!(f, "{}", printable)
+    }
+}

--- a/cita-executor/core/src/cita_executive.rs
+++ b/cita-executor/core/src/cita_executive.rs
@@ -2,25 +2,25 @@ use cita_trie::DB;
 use cita_types::{Address, H160, H256, U256, U512};
 use cita_vm::{
     evm::{Context as EVMContext, Error as EVMError, InterpreterResult, Log as EVMLog},
-    state::{Error as StateError, State, StateObjectInfo},
+    state::{State, StateObjectInfo},
     BlockDataProvider, Config as VMConfig, DataProvider, Error as VMError, Store as VmSubState,
     Transaction as EVMTransaction,
 };
 use hashable::Hashable;
 use std::cell::RefCell;
-use std::error::Error;
-use std::fmt;
 use std::sync::Arc;
 use types::Bytes;
 
-use crate::authentication::{check_permission, AuthenticationError};
-use crate::contracts::native::factory::{Factory as NativeFactory, NativeError};
+use crate::authentication::check_permission;
+use crate::contracts::native::factory::Factory as NativeFactory;
 use crate::core_types::{Bloom, BloomInput, Hash};
-use crate::executed::CallError;
+use crate::exception::ExecutedException;
 use crate::libexecutor::economical_model::EconomicalModel;
 use crate::libexecutor::sys_config::BlockSysConfig;
 use crate::tx_gas_schedule::TxGasSchedule;
 use crate::types::context::Context;
+use crate::types::errors::AuthenticationError;
+use crate::types::errors::ExecutionError;
 use crate::types::log_entry::LogEntry;
 use crate::types::transaction::{Action, SignedTransaction};
 
@@ -102,9 +102,7 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
         }
 
         if t.action == Action::AbiStore && !self.transact_set_abi(&t.data) {
-            return Err(ExecutionError::TransactionMalformed(
-                "Account doesn't exist".to_owned(),
-            ));
+            return Err(ExecutionError::InvalidTransaction);
         }
 
         let init_gas = t.gas - U256::from(base_gas_required);
@@ -682,77 +680,6 @@ pub fn contract_address(address: &Address, nonce: &U256) -> Address {
     From::from(stream.out().crypt_hash())
 }
 
-// All the EVMError will be set into ExecutedResult's exception.
-// And some of them which need return Err in CitaExecutive.exec will be set to ExecutionError too.
-/// Error Result for execute a transaction
-#[derive(Debug, PartialEq)]
-pub enum ExecutionError {
-    /// Return when internal vm error occurs.
-    Internal(String),
-    /// Return when generic transaction occurs.
-    TransactionMalformed(String),
-    /// Return when authentication error occurs.
-    Authentication(AuthenticationError),
-    /// Return when the quota_limit in transaction lower then base quota required.
-    NotEnoughBaseGas,
-    /// Return when transaction nonce does not match state nonce.
-    InvalidNonce,
-    /// Return when the cost of transaction (value + quota_price * quota) exceeds.
-    NotEnoughBalance,
-    /// Return when the block quota exceeds block quota limit.
-    BlockQuotaLimitReached,
-    /// Return when sum quota for account in the block exceeds account quota limit.
-    AccountQuotaLimitReached,
-}
-
-impl Error for ExecutionError {}
-impl fmt::Display for ExecutionError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let printable = match *self {
-            ExecutionError::Internal(ref err) => format!("internal error: {:?}", err),
-            ExecutionError::TransactionMalformed(ref err) => format!("internal error: {:?}", err),
-            ExecutionError::Authentication(ref err) => format!("internal error: {:?}", err),
-            ExecutionError::NotEnoughBaseGas => "not enough base gas".to_owned(),
-            ExecutionError::InvalidNonce => "invalid nonce".to_owned(),
-            ExecutionError::NotEnoughBalance => "not enough balance".to_owned(),
-            ExecutionError::BlockQuotaLimitReached => "block quota limit reached".to_owned(),
-            ExecutionError::AccountQuotaLimitReached => "account quota limit reached".to_owned(),
-        };
-        write!(f, "{}", printable)
-    }
-}
-
-impl From<NativeError> for ExecutionError {
-    fn from(err: NativeError) -> Self {
-        match err {
-            NativeError::Internal(err_str) => ExecutionError::Internal(err_str),
-        }
-    }
-}
-
-impl From<AuthenticationError> for ExecutionError {
-    fn from(err: AuthenticationError) -> Self {
-        match err {
-            AuthenticationError::TransactionMalformed(err_str) => {
-                ExecutionError::TransactionMalformed(err_str)
-            }
-            _ => ExecutionError::Authentication(err),
-        }
-    }
-}
-
-impl From<StateError> for ExecutionError {
-    fn from(err: StateError) -> Self {
-        ExecutionError::Internal(format!("{}", err))
-    }
-}
-
-impl Into<CallError> for ExecutionError {
-    fn into(self) -> CallError {
-        CallError::Exceptional
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct VmExecParams {
     /// Address of currently executed code.
@@ -786,41 +713,6 @@ impl Default for VmExecParams {
             nonce: U256::zero(),
             data: None,
         }
-    }
-}
-
-// There is not reverted expcetion in VMError, so handle this in ExecutedException.
-#[derive(Debug)]
-pub enum ExecutedException {
-    VM(VMError),
-    NativeContract(NativeError),
-    Reverted,
-}
-
-impl Error for ExecutedException {}
-
-impl fmt::Display for ExecutedException {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let printable = match *self {
-            ExecutedException::VM(ref err) => format!("exception in vm: {:?}", err),
-            ExecutedException::NativeContract(ref err) => {
-                format!("exception in native contract: {:?}", err)
-            }
-            ExecutedException::Reverted => "execution reverted".to_owned(),
-        };
-        write!(f, "{}", printable)
-    }
-}
-
-impl From<VMError> for ExecutedException {
-    fn from(err: VMError) -> Self {
-        ExecutedException::VM(err)
-    }
-}
-
-impl From<NativeError> for ExecutedException {
-    fn from(err: NativeError) -> Self {
-        ExecutedException::NativeContract(err)
     }
 }
 

--- a/cita-executor/core/src/contracts/native/crosschain_verify.rs
+++ b/cita-executor/core/src/contracts/native/crosschain_verify.rs
@@ -8,9 +8,9 @@ use core::header::Header;
 use core::libchain::chain::TxProof;
 use ethabi;
 
-use crate::contracts::native::factory::NativeError;
 use crate::storage::Map;
 use crate::types::context::Context;
+use crate::types::errors::NativeError;
 use cita_vm::evm::DataProvider;
 use cita_vm::evm::InterpreterResult;
 

--- a/cita-executor/core/src/contracts/native/factory.rs
+++ b/cita-executor/core/src/contracts/native/factory.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::fmt;
 use std::str::FromStr;
 
 use crate::cita_executive::VmExecParams;
 use crate::types::context::Context;
+use crate::types::errors::NativeError;
 use crate::types::reserved_addresses;
 
 use cita_types::Address;
@@ -94,19 +94,5 @@ impl Default for Factory {
             );
         }
         factory
-    }
-}
-
-#[derive(Debug)]
-pub enum NativeError {
-    Internal(String),
-}
-
-impl fmt::Display for NativeError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let printable = match self {
-            NativeError::Internal(str) => format!("Internal error {:?}", str),
-        };
-        write!(f, "{}", printable)
     }
 }

--- a/cita-executor/core/src/contracts/native/mod.rs
+++ b/cita-executor/core/src/contracts/native/mod.rs
@@ -6,4 +6,4 @@ mod simple_storage;
 #[cfg(feature = "privatetx")]
 mod zk_privacy;
 
-pub use factory::{Contract, NativeError};
+pub use factory::Contract;

--- a/cita-executor/core/src/contracts/tools/method.rs
+++ b/cita-executor/core/src/contracts/tools/method.rs
@@ -15,9 +15,9 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-/// Calculate contract method signature hash and return different types.
-use crate::contracts::native::factory::NativeError;
+use crate::types::errors::NativeError;
 use byteorder::{BigEndian, ByteOrder};
+/// Calculate contract method signature hash and return different types.
 use util::sha3;
 
 pub fn encode_to_array(name: &[u8]) -> [u8; 4] {

--- a/cita-executor/core/src/exception.rs
+++ b/cita-executor/core/src/exception.rs
@@ -1,0 +1,40 @@
+use std::error::Error;
+use std::fmt;
+
+use crate::types::errors::NativeError;
+use cita_vm::Error as VMError;
+
+// There is not reverted expcetion in VMError, so handle this in ExecutedException.
+#[derive(Debug)]
+pub enum ExecutedException {
+    VM(VMError),
+    NativeContract(NativeError),
+    Reverted,
+}
+
+impl Error for ExecutedException {}
+
+impl fmt::Display for ExecutedException {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let printable = match *self {
+            ExecutedException::VM(ref err) => format!("exception in vm: {:?}", err),
+            ExecutedException::NativeContract(ref err) => {
+                format!("exception in native contract: {:?}", err)
+            }
+            ExecutedException::Reverted => "execution reverted".to_owned(),
+        };
+        write!(f, "{}", printable)
+    }
+}
+
+impl From<VMError> for ExecutedException {
+    fn from(err: VMError) -> Self {
+        ExecutedException::VM(err)
+    }
+}
+
+impl From<NativeError> for ExecutedException {
+    fn from(err: NativeError) -> Self {
+        ExecutedException::NativeContract(err)
+    }
+}

--- a/cita-executor/core/src/executed.rs
+++ b/cita-executor/core/src/executed.rs
@@ -16,13 +16,14 @@
 
 //! Transaction execution format module.
 
-use std::fmt;
-
-use crate::types::errors::ReceiptError;
+use crate::types::errors::ExecutionError;
 use crate::types::log_entry::LogEntry;
 
-use cita_types::{Address, U256, U512};
+use cita_types::{Address, U256};
 use types::Bytes;
+
+/// Transaction execution result.
+pub type ExecutionResult = Result<Executed, ExecutionError>;
 
 /// Transaction execution receipt.
 #[derive(Debug)]
@@ -64,141 +65,4 @@ pub struct Executed {
     //pub state_diff: Option<StateDiff>,
     /// Transaction sender account nonce
     pub account_nonce: U256,
-}
-
-/// Result of executing the transaction.
-#[derive(PartialEq, Debug, Clone)]
-#[cfg_attr(feature = "ipc", binary)]
-pub enum ExecutionError {
-    /// Returned when there gas paid for transaction execution is
-    /// lower than base gas required.
-    NotEnoughBaseGas {
-        /// Absolute minimum gas required.
-        required: U256,
-        /// Gas provided.
-        got: U256,
-    },
-    /// Returned when block (gas_used + gas) > gas_limit.
-    ///
-    /// If gas =< gas_limit, upstream may try to execute the transaction
-    /// in next block.
-    BlockGasLimitReached {
-        /// Gas limit of block for transaction.
-        gas_limit: U256,
-        /// Gas used in block prior to transaction.
-        gas_used: U256,
-        /// Amount of gas in block.
-        gas: U256,
-    },
-    AccountGasLimitReached {
-        /// Account Gas limit left
-        gas_limit: U256,
-        /// Amount of gas in transaction
-        gas: U256,
-    },
-    /// Returned when transaction nonce does not match state nonce.
-    InvalidNonce {
-        /// Nonce expected.
-        expected: U256,
-        /// Nonce found.
-        got: U256,
-    },
-    /// Returned when cost of transaction (value + gas_price * gas) exceeds
-    /// current sender balance.
-    NotEnoughCash {
-        /// Minimum required balance.
-        required: U512,
-        /// Actual balance.
-        got: U512,
-    },
-    NoTransactionPermission,
-    NoContractPermission,
-    NoCallPermission,
-    /// Returned when internal evm error occurs.
-    ExecutionInternal(String),
-    /// Returned when generic transaction occurs
-    TransactionMalformed(String),
-}
-
-impl fmt::Display for ExecutionError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::ExecutionError::*;
-
-        let msg = match *self {
-            NotEnoughBaseGas { ref required, ref got } => format!("Not enough base quota. {} is required, but only {} paid", required, got),
-            BlockGasLimitReached {
-                ref gas_limit,
-                ref gas_used,
-                ref gas,
-            } => format!("Block quota limit reached. The limit is {}, {} has already been used, and {} more is required", gas_limit, gas_used, gas),
-            AccountGasLimitReached { ref gas_limit, ref gas } => format!("Account quota limit reached. The limit is {}, {} more is required", gas_limit, gas),
-            InvalidNonce { ref expected, ref got } => format!("Invalid transaction nonce: expected {}, found {}", expected, got),
-            NotEnoughCash { ref required, ref got } => format!("Cost of transaction exceeds sender balance. {} is required but the sender only has {}", required, got),
-            ExecutionInternal(ref msg) => msg.clone(),
-            TransactionMalformed(ref err) => format!("Malformed transaction: {}", err),
-            NoTransactionPermission => "No transaction permission".to_owned(),
-            NoContractPermission => "No contract permission".to_owned(),
-            NoCallPermission => "No call contract permission".to_owned(),
-        };
-
-        f.write_fmt(format_args!("Transaction execution error ({}).", msg))
-    }
-}
-
-/// Result of executing the transaction.
-#[derive(PartialEq, Debug, Clone)]
-#[cfg_attr(feature = "ipc", binary)]
-pub enum CallError {
-    /// Couldn't find the transaction in the chain.
-    TransactionNotFound,
-    /// Couldn't find requested block's state in the chain.
-    StatePruned,
-    /// Couldn't find an amount of gas that didn't result in an exception.
-    Exceptional,
-    /// Corrupt state.
-    StateCorrupt,
-    /// Error executing.
-    Execution(ExecutionError),
-}
-
-impl From<ExecutionError> for CallError {
-    fn from(error: ExecutionError) -> Self {
-        CallError::Execution(error)
-    }
-}
-
-impl fmt::Display for CallError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::CallError::*;
-
-        let msg = match *self {
-            TransactionNotFound => "Transaction couldn't be found in the chain".into(),
-            StatePruned => "Couldn't find the transaction block's state in the chain".into(),
-            Exceptional => "An exception happened in the execution".into(),
-            StateCorrupt => "Stored state found to be corrupted.".into(),
-            Execution(ref e) => format!("{}", e),
-        };
-
-        f.write_fmt(format_args!("Transaction execution error ({}).", msg))
-    }
-}
-
-/// Transaction execution result.
-pub type ExecutionResult = Result<Executed, ExecutionError>;
-
-impl From<ExecutionError> for ReceiptError {
-    fn from(error: ExecutionError) -> Self {
-        match error {
-            ExecutionError::NotEnoughBaseGas { .. } => ReceiptError::NotEnoughBaseQuota,
-            ExecutionError::BlockGasLimitReached { .. } => ReceiptError::BlockQuotaLimitReached,
-            ExecutionError::AccountGasLimitReached { .. } => ReceiptError::AccountQuotaLimitReached,
-            ExecutionError::InvalidNonce { .. } => ReceiptError::InvalidNonce,
-            ExecutionError::NotEnoughCash { .. } => ReceiptError::NotEnoughCash,
-            ExecutionError::NoTransactionPermission => ReceiptError::NoTransactionPermission,
-            ExecutionError::NoContractPermission => ReceiptError::NoContractPermission,
-            ExecutionError::NoCallPermission => ReceiptError::NoCallPermission,
-            ExecutionError::ExecutionInternal { .. } => ReceiptError::ExecutionInternal,
-            ExecutionError::TransactionMalformed { .. } => ReceiptError::TransactionMalformed,
-        }
-    }
 }

--- a/cita-executor/core/src/lib.rs
+++ b/cita-executor/core/src/lib.rs
@@ -82,6 +82,7 @@ pub mod tests;
 
 pub mod authentication;
 pub mod contracts;
+pub mod exception;
 pub mod libexecutor;
 pub mod trie_db;
 

--- a/cita-executor/core/src/libexecutor/block.rs
+++ b/cita-executor/core/src/libexecutor/block.rs
@@ -31,10 +31,10 @@ use hashable::Hashable;
 use libproto::executor::{ExecutedInfo, ReceiptWithOption};
 use rlp::Encodable;
 
-use crate::authentication::AuthenticationError;
-use crate::cita_executive::{CitaExecutive, ExecutedException, ExecutionError};
+use crate::cita_executive::CitaExecutive;
 use crate::contracts::native::factory::Factory as NativeFactory;
 use crate::core::context::{Context, LastHashes};
+use crate::exception::ExecutedException;
 use crate::libexecutor::auto_exec::auto_exec;
 use crate::libexecutor::economical_model::EconomicalModel;
 use crate::libexecutor::executor::CitaTrieDB;
@@ -45,6 +45,7 @@ use crate::tx_gas_schedule::TxGasSchedule;
 pub use crate::types::block::{Block, BlockBody, OpenBlock};
 use crate::types::errors::Error;
 use crate::types::errors::ReceiptError;
+use crate::types::errors::{AuthenticationError, ExecutionError};
 use crate::types::transaction::SignedTransaction;
 
 lazy_static! {
@@ -240,9 +241,7 @@ impl ExecutedBlock {
                         Some(ReceiptError::NoCallPermission)
                     }
                     ExecutionError::Internal { .. } => Some(ReceiptError::ExecutionInternal),
-                    ExecutionError::TransactionMalformed { .. } => {
-                        Some(ReceiptError::TransactionMalformed)
-                    }
+                    ExecutionError::InvalidTransaction => Some(ReceiptError::TransactionMalformed),
                     _ => Some(ReceiptError::Internal),
                 };
 

--- a/cita-executor/core/src/libexecutor/command.rs
+++ b/cita-executor/core/src/libexecutor/command.rs
@@ -24,13 +24,13 @@ use crate::contracts::native::factory::Factory as NativeFactory;
 use crate::contracts::solc::{
     sys_config::ChainId, PermissionManagement, SysConfig, VersionManager,
 };
-use crate::executed::CallError;
 use crate::libexecutor::block::EVMBlockDataProvider;
 pub use crate::libexecutor::block::*;
 use crate::libexecutor::call_request::CallRequest;
 use crate::trie_db::TrieDB;
 use crate::types::block_number::{BlockTag, Tag};
 use crate::types::context::Context;
+use crate::types::errors::CallError;
 use crate::types::transaction::{Action, SignedTransaction, Transaction};
 pub use byteorder::{BigEndian, ByteOrder};
 use cita_database::RocksDB;

--- a/cita-executor/core/src/storage.rs
+++ b/cita-executor/core/src/storage.rs
@@ -3,7 +3,7 @@ use std::boxed::Box;
 use std::convert::From;
 use util::sha3;
 
-use crate::contracts::native::factory::NativeError;
+use crate::types::errors::NativeError;
 use cita_vm::evm::DataProvider;
 
 pub trait Serialize {


### PR DESCRIPTION
# refactor errors in chain and executor 

### Description of the Change

1. New `ExecutionError`

```rs
pub enum ExecutionError {
    Internal(String),
    Authentication(AuthenticationError),
    VM(VMError),
    NativeContract(NativeError),
    Call(CallError),
    Reverted,
    InvalidTransaction,
    AccountQuotaLimitReached, // FixMe: AccountQuotaLimitReached should be located in cita-vm, the same with ExccedMaxBlockGasLimit
}
````

* Remove `NotEnoughBaseGas`, `InvalidNonce`, `NotEnoughBalance`, `BlockQuotaLimitReached` in original `ExecutionError` and use cita-vm error types directly.
* Take `VM(VMError)`, `NativeContract(NativeError)`, `Reverted` out and delete `ExecutionException` in cita_executive.rs.

2. New `CallError`

```rs
#[derive(Debug)]
pub enum CallError {
    /// Couldn't find the transaction in the chain.
    TransactionNotFound,
    /// Couldn't find requested block's state in the chain.
    StatePruned,
    /// Couldn't find an amount of gas that didn't result in an exception.
    Exceptional,
    /// Corrupt state.
    StateCorrupt,
}
```

* Remove `Execution(ExecutionError)` and integrate `CallError` into `ExecutionError`.

After this pr, `cita-chain/types/errors` looks like this:

```sh
errors
    │   ├── authentication.rs
    │   ├── call.rs
    │   ├── execution.rs
    │   ├── mod.rs
    │   ├── native.rs
    │   └── receipt.rs
```

In a word, I want to ensure that all errors returned by execution failure are consistent as `ExecutionError`.
