### PR TITLE
Return revert from exception

### DIFF
--- a/cita-executor/core/src/cita_executive.rs
+++ b/cita-executor/core/src/cita_executive.rs
@@ -616,6 +616,8 @@ fn build_result_with_ok(init_gas: U256, ret: InterpreterResult) -> ExecutedResul
         InterpreterResult::Revert(data, quota_left) => {
             result.quota_used = init_gas - U256::from(quota_left);
             result.quota_left = U256::from(quota_left);
+            result.exception = Some(ExecutedException::Reverted);
+
             trace!(
                 "Get data after executed the transaction [Revert]: {:?}",
                 data
@@ -638,6 +640,7 @@ fn build_result_with_ok(init_gas: U256, ret: InterpreterResult) -> ExecutedResul
 }
 
 fn build_result_with_err(err: VMError) -> ExecutedResult {
+    trace!("EVM run error for the transaction, error info: {:?}", err);
     let mut result = ExecutedResult::default();
     result.exception = Some(ExecutedException::VM(err));
     result


### PR DESCRIPTION
return revert from exception.

Self test:

1. Deploy contract:
```
cita> rpc sendRawTransaction --code 0x608060405234801561001057600080fd5b5060fd8061001f6000396000f3006080604052600436106049576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630c55699c14604e5780632d910f2c146076575b600080fd5b348015605957600080fd5b506060608a565b6040518082815260200191505060405180910390f35b348015608157600080fd5b5060886090565b005b60005481565b600160008082825401925050819055506000547f11c1a8e7158fead62641b1e07f61c32daccb5a0432cabfe33a43e8de610042f160405160405180910390a25600a165627a7a7230582021264d3aa498b31d10a5a7086d3e3ba4fb8c23f5a30b64ef8426b19ae2de29870029 --private-key 0x39079ed55c06f6316d3f936376b35589afa9e90fd7b2384e91cee0c5acc2fa97
{
  "id": 4,
  "jsonrpc": "2.0",
  "result": {
    "hash": "0x2a5496ab5c89589243e3fc90a39d49523efd4f7651800994d1f182bee418bd73",
    "status": "OK"
  }
}
```
2. Get contract address:
```
cita> rpc getTransactionReceipt --hash 0x2a5496ab5c89589243e3fc90a39d49523efd4f7651800994d1f182bee418bd73
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x933b8cb13d9319528f7586434385dc7b2ee07d23f1c720949b5f0ab07eab0cab",
    "blockNumber": "0x6",
    "contractAddress": "0x81ce4045a9025fcee3a51206a9003a48936b45d0",
    "cumulativeQuotaUsed": "0x19513",
    "errorMessage": null,
    "logs": [
    ],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "quotaUsed": "0x19513",
    "root": null,
    "transactionHash": "0x2a5496ab5c89589243e3fc90a39d49523efd4f7651800994d1f182bee418bd73",
    "transactionIndex": "0x0"
  }
}
```

3. Batch call contract, using a wrong function signatures (`1d910f2c`) for the second transaction:
```
cita> scm BatchTx multiTxs --tx-code 0x81ce4045a9025fcee3a51206a9003a48936b45d02d910f2c --tx-code 0x81ce4045a9025fcee3a51206a9003a48936b45d01d910f2c --private-key 0x39079ed55c06f6316d3f936376b35589afa9e90fd7b2384e91cee0c5acc2fa97
{
  "id": 4,
  "jsonrpc": "2.0",
  "result": {
    "hash": "0x08b90129035c3f4398f92f9672dfa366282169cdd75818e3bd9dcb37c36a0b66",
    "status": "OK"
  }
}
```

4. Get the `Reverted` errorMessage:
```
cita> rpc getTransactionReceipt --hash 0x08b90129035c3f4398f92f9672dfa366282169cdd75818e3bd9dcb37c36a0b66
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": {
    "blockHash": "0x2673f7e302dd8d0df90ad2dfb06b37a76c91a933b8864fa6a8d7a3c76fc1135c",
    "blockNumber": "0x12f",
    "contractAddress": null,
    "cumulativeQuotaUsed": "0x989680",
    "errorMessage": "Reverted.",
    "logs": [
    ],
    "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
    "quotaUsed": "0x989680",
    "root": null,
    "transactionHash": "0x08b90129035c3f4398f92f9672dfa366282169cdd75818e3bd9dcb37c36a0b66",
    "transactionIndex": "0x0"
  }
}
```
