### PR TITLE
Prune the filter id when uninstall.

### DIFF
--- a/cita-chain/core/src/filters/filterdb.rs
+++ b/cita-chain/core/src/filters/filterdb.rs
@@ -111,6 +111,7 @@ impl FilterDB {
 
     /// Uninstall the filter id
     pub fn uninstall(&mut self, id: usize) -> bool {
+        self.prune();
         // Remove logs first. casue logs filter includes the block filter.
         if self.is_logs_filter(id) {
             self.logs_filter.remove(id);


### PR DESCRIPTION
### Description of the Change

Prune the hashmap when uninstall the filter.
