### PR TITLE
Fix newFilter: should add current block.

### DIFF
--- a/cita-chain/core/src/filters/rpc_filter.rs
+++ b/cita-chain/core/src/filters/rpc_filter.rs
@@ -66,7 +66,12 @@ impl RpcFilter for Chain {
     fn new_filter(&self, filter: Filter) -> usize {
         let filterdb = self.filter_db();
         let id = filterdb.try_lock().unwrap().gen_id();
+        let block_number = self.get_current_height();
         filterdb.try_lock().unwrap().gen_logs_filter(id, filter);
+        filterdb
+            .try_lock()
+            .unwrap()
+            .gen_block_filter(id, block_number);
         drop(filterdb);
         id
     }


### PR DESCRIPTION

### Description of the Change

The block number is a part of filter.
`newFilter` should record the current block number.
