### PR TITLE
refactoring executive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,7 +779,7 @@ dependencies = [
 [[package]]
 name = "cita-vm"
 version = "0.2.1"
-source = "git+https://github.com/cryptape/cita-vm.git?branch=cita#535c36d3a945236982e12b0add124d4cd078c4a2"
+source = "git+https://github.com/cryptape/cita-vm.git?branch=cita#85ce6b27be59616ab4c90b28559d2fc243523539"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita_trie 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -948,6 +948,8 @@ dependencies = [
  "ethabi 4.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethbloom 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashable 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
+ "hashbrown 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hasher 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "largest-remainder-method 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cita-chain/types/src/context.rs
+++ b/cita-chain/types/src/context.rs
@@ -14,6 +14,7 @@
 
 use crate::header::BlockNumber;
 use cita_types::{Address, H256, U256};
+use cita_vm::evm::Context as EVMContext;
 use std::sync::Arc;
 
 pub type LastHashes = Vec<H256>;
@@ -41,6 +42,19 @@ impl Default for Context {
             last_hashes: Arc::new(vec![]),
             quota_used: U256::default(),
             account_quota_limit: U256::default(),
+        }
+    }
+}
+
+impl From<EVMContext> for Context {
+    fn from(evm_context: EVMContext) -> Context {
+        Context {
+            block_quota_limit: U256::from(evm_context.gas_limit),
+            coin_base: evm_context.coinbase,
+            block_number: evm_context.number.as_u64(),
+            timestamp: evm_context.timestamp,
+            difficulty: evm_context.difficulty,
+            ..Default::default()
         }
     }
 }

--- a/cita-chain/types/src/errors/native.rs
+++ b/cita-chain/types/src/errors/native.rs
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cita_vm::evm::Error as EVMError;
+use cita_vm::Error as VMError;
 use std::fmt;
 
 #[derive(Debug)]
 pub enum NativeError {
     Internal(String),
+}
+
+impl Into<VMError> for NativeError {
+    fn into(self) -> VMError {
+        match self {
+            NativeError::Internal(str) => VMError::Evm(EVMError::Internal(str)),
+        }
+    }
 }
 
 impl fmt::Display for NativeError {

--- a/cita-executor/core/Cargo.toml
+++ b/cita-executor/core/Cargo.toml
@@ -32,6 +32,8 @@ cita_trie = "2.0"
 ethbloom = "0.6"
 sha3 = { version="0.8", optional=true }
 tiny-keccak = { version="1.4", optional=true }
+hashbrown = { version = "0.3", features = ["rayon"] }
+hasher = { version="0.1" }
 
 common-types = { path = "../../cita-chain/types" }
 core = { path = "../../cita-chain/core" }

--- a/cita-executor/core/src/cita_executive.rs
+++ b/cita-executor/core/src/cita_executive.rs
@@ -616,8 +616,10 @@ pub fn create<B: DB + 'static>(
                 state_provider.borrow_mut().revert_checkpoint();
                 return Err(VMError::ExccedMaxCodeSize);
             }
+            let tx_gas_schedule = TxGasSchedule::default();
             // Pay every byte returnd from CREATE
-            let gas_code_deposit: u64 = 200 * output.len() as u64;
+            let gas_code_deposit: u64 =
+                tx_gas_schedule.create_data_gas as u64 * output.len() as u64;
             if gas_left < gas_code_deposit {
                 state_provider.borrow_mut().revert_checkpoint();
                 return Err(VMError::Evm(evm::Error::OutOfGas));

--- a/cita-executor/core/src/cita_executive.rs
+++ b/cita-executor/core/src/cita_executive.rs
@@ -12,19 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use crate::data_provider::{BlockDataProvider, DataProvider, Store as VMSubState};
 use cita_trie::DB;
 use cita_types::{Address, H160, H256, U256, U512};
 use cita_vm::{
-    evm::{Context as EVMContext, Error as EVMError, InterpreterResult, Log as EVMLog},
+    evm::{
+        self, Context as EVMContext, Contract, Error as EVMError, InterpreterParams,
+        InterpreterResult, Log as EVMLog,
+    },
     state::{State, StateObjectInfo},
-    BlockDataProvider, Config as VMConfig, DataProvider, Error as VMError, Store as VmSubState,
-    Transaction as EVMTransaction,
+    summary, Error as VMError,
 };
+use rlp::RlpStream;
 use std::cell::RefCell;
 use std::sync::Arc;
 use types::Bytes;
 
 use crate::authentication::check_permission;
+use crate::cita_vm_helper::{call_pure, get_interpreter_conf};
 use crate::contracts::native::factory::Factory as NativeFactory;
 use crate::exception::ExecutedException;
 use crate::libexecutor::economical_model::EconomicalModel;
@@ -48,11 +53,13 @@ const AMEND_GET_KV_H256: u32 = 4;
 ///amend account's balance
 const AMEND_ACCOUNT_BALANCE: u32 = 5;
 
+/// See: https://github.com/ethereum/EIPs/issues/659
+const MAX_CREATE_CODE_SIZE: u64 = std::u64::MAX;
+
 // FIXME: CITAExecutive need rename to Executive after all works ready.
 pub struct CitaExecutive<'a, B> {
     block_provider: Arc<BlockDataProvider>,
     state_provider: Arc<RefCell<State<B>>>,
-    native_factory: &'a NativeFactory,
     context: &'a Context,
     economical_model: EconomicalModel,
 }
@@ -61,14 +68,12 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
     pub fn new(
         block_provider: Arc<BlockDataProvider>,
         state: Arc<RefCell<State<B>>>,
-        native_factory: &'a NativeFactory,
         context: &'a Context,
         economical_model: EconomicalModel,
     ) -> Self {
         Self {
             block_provider,
             state_provider: state,
-            native_factory,
             context,
             economical_model,
         }
@@ -104,7 +109,6 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
             0...2 => 0,
             _ => t.data.len() * tx_gas_schedule.tx_data_non_zero_gas,
         };
-
         if sender != Address::zero() && t.gas < U256::from(base_gas_required) {
             // FIXME: It is better to change NotEnoughBaseGas to
             //    NotEnoughBaseGas {
@@ -119,22 +123,22 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
             return Err(ExecutionError::InvalidTransaction);
         }
 
+        // Prepaid t.gas for the transaction.
+        self.prepaid(t.sender(), t.gas, t.gas_price, t.value)?;
         let init_gas = t.gas - U256::from(base_gas_required);
+
+        let mut store = VMSubState::default();
+        store.evm_context = build_evm_context(&self.context.clone());
+        store.evm_cfg = get_interpreter_conf();
+        let store = Arc::new(RefCell::new(store));
 
         let result = match t.action {
             Action::Store | Action::AbiStore => {
-                // Prepaid t.gas for the transaction.
-                self.prepaid(t.sender(), t.gas, t.gas_price, t.value)?;
-
                 // Maybe use tx_gas_schedule.tx_data_non_zero_gas for each byte store, it is more reasonable.
                 // But for the data compatible, just let it as tx_gas_schedule.create_data_gas for now.
                 let store_gas_used = U256::from(t.data.len() * tx_gas_schedule.create_data_gas);
                 if let Some(gas_left) = init_gas.checked_sub(store_gas_used) {
-                    let mut result = ExecutedResult::default();
-                    result.quota_left = gas_left;
-                    result.is_evm_call = false;
-
-                    Ok(result)
+                    Ok(InterpreterResult::Normal(vec![], gas_left.as_u64(), vec![]))
                 } else {
                     // FIXME: Should not return an error after self.prepaid().
                     // But for compatibility, should keep this. Need to be upgrade in new version.
@@ -143,18 +147,28 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
             }
             Action::Create => {
                 // Note: Fees has been handle in cita_vm.
-                let params = VmExecParams {
+                let params = ExecutiveParams {
                     code_address: None,
                     sender,
                     to_address: None,
-                    gas: t.gas,
+                    gas: init_gas,
                     gas_price: t.gas_price(),
                     value: t.value,
                     nonce,
                     data: Some(t.data.clone()),
                 };
 
-                self.call_evm(&params)
+                let mut vm_exec_params = build_vm_exec_params(&params, self.state_provider.clone());
+                if !self.payment_required() {
+                    vm_exec_params.disable_transfer_value = true;
+                }
+                create(
+                    self.block_provider.clone(),
+                    self.state_provider.clone(),
+                    store.clone(),
+                    &vm_exec_params.into(),
+                    CreateKind::FromAddressAndNonce,
+                )
             }
 
             Action::AmendData => {
@@ -171,9 +185,6 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
                     ));
                 }
 
-                // Prepaid for the transaction
-                self.prepaid(t.sender(), t.gas, t.gas_price, t.value)?;
-
                 // Backup used in case of running error
                 self.state_provider.borrow_mut().checkpoint();
 
@@ -181,101 +192,186 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
                     Ok(Some(val)) => {
                         // Discard the checkpoint because of amend data ok.
                         self.state_provider.borrow_mut().discard_checkpoint();
-
-                        let mut result = ExecutedResult::default();
-                        // Refund gas, AmendData do not use any additional gas.
-                        result.quota_left = init_gas;
-                        result.is_evm_call = false;
-                        result.output = val.to_vec();
-                        Ok(result)
+                        Ok(InterpreterResult::Normal(
+                            val.to_vec(),
+                            init_gas.as_u64(),
+                            vec![],
+                        ))
                     }
                     Ok(None) => {
                         // Discard the checkpoint because of amend data ok.
                         self.state_provider.borrow_mut().discard_checkpoint();
-
-                        let mut result = ExecutedResult::default();
-                        // Refund gas, AmendData do not use any additional gas.
-                        result.quota_left = init_gas;
-                        result.is_evm_call = false;
-                        Ok(result)
+                        Ok(InterpreterResult::Normal(vec![], init_gas.as_u64(), vec![]))
                     }
                     Err(e) => {
-                        let mut result = ExecutedResult::default();
-
                         // Need to revert the state.
                         self.state_provider.borrow_mut().revert_checkpoint();
-                        result.exception = Some(ExecutedException::VM(e));
-                        result.is_evm_call = false;
-                        Ok(result)
+                        Err(e)
                     }
                 }
             }
             Action::Call(ref address) => {
-                let params = VmExecParams {
+                let params = ExecutiveParams {
                     code_address: Some(*address),
                     sender,
                     to_address: Some(*address),
-                    gas: t.gas,
+                    gas: init_gas,
                     gas_price: t.gas_price(),
                     value: t.value,
                     nonce,
                     data: Some(t.data.clone()),
                 };
-                self.call(&params)
-            }
-        };
-
-        let mut finalize_result = match result {
-            Ok(res) => {
-                if let Some(ref e) = res.exception {
-                    if let Some(err) = self.transform_base_gas_err(e) {
-                        return Err(err);
-                    }
+                let mut vm_exec_params = build_vm_exec_params(&params, self.state_provider.clone());
+                if !self.payment_required() {
+                    vm_exec_params.disable_transfer_value = true;
                 }
-                res
-            }
-            Err(_) => {
-                // Don't care about what is the error info in this situation, just let it as
-                // ReceiptError::Internal in Receipt.
-                let mut r = ExecutedResult::default();
-                r.quota_left = U256::from(0);
-                r.quota_used = t.gas;
-                r.is_evm_call = false;
-                r
+                call(
+                    self.block_provider.clone(),
+                    self.state_provider.clone(),
+                    store.clone(),
+                    &vm_exec_params.into(),
+                )
             }
         };
 
-        if !finalize_result.is_evm_call {
-            let refund_value = finalize_result.quota_left * t.gas_price;
-            // Note: should not be error at refund.
-            self.refund(t.sender(), refund_value)
-                .expect("refund balance to sender must success");
-
-            let quota_used = t.gas - finalize_result.quota_left;
-            let fee_value = quota_used * t.gas_price;
-            self.handle_tx_fee(&self.context.coin_base, fee_value)
-                .expect("Add balance to coin_base must success");
-            finalize_result.quota_used = quota_used;
-        }
-
+        let mut finalize_result = self.finalize(result, store, t.gas, sender, t.gas_price());
         finalize_result.account_nonce = nonce;
         Ok(finalize_result)
     }
 
-    fn transform_base_gas_err(&self, e: &ExecutedException) -> Option<ExecutionError> {
-        match e {
-            ExecutedException::VM(VMError::ExccedMaxBlockGasLimit) => {
-                Some(ExecutionError::BlockQuotaLimitReached)
+    fn finalize(
+        &mut self,
+        result: Result<InterpreterResult, VMError>,
+        store: Arc<RefCell<VMSubState>>,
+        gas_limit: U256,
+        sender: Address,
+        gas_price: U256,
+    ) -> ExecutedResult {
+        let mut finalize_result = ExecutedResult::default();
+
+        match result {
+            Ok(InterpreterResult::Normal(output, gas_left, logs)) => {
+                if self.payment_required() {
+                    let refund = get_refund(store.clone(), sender, gas_limit.as_u64(), gas_left);
+                    if let Err(e) = liquidtion(
+                        self.state_provider.clone(),
+                        store.clone(),
+                        sender,
+                        gas_price,
+                        gas_limit.as_u64(),
+                        gas_left,
+                        refund,
+                    ) {
+                        finalize_result.exception = Some(ExecutedException::VM(e));
+                        return finalize_result;
+                    }
+                }
+                // Handle self destruct: Kill it.
+                // Note: must after ends of the transaction.
+                for e in store.borrow_mut().selfdestruct.drain() {
+                    self.state_provider.borrow_mut().kill_contract(&e);
+                }
+                self.state_provider
+                    .borrow_mut()
+                    .kill_garbage(&store.borrow().inused.clone());
+                finalize_result.quota_used = gas_limit - U256::from(gas_left);
+                finalize_result.quota_left = U256::from(gas_left);
+                finalize_result.logs = transform_logs(logs);
+                finalize_result.logs_bloom = logs_to_bloom(&finalize_result.logs);
+
+                trace!(
+                    "Get data after executed the transaction [Normal]: {:?}",
+                    output
+                );
+                finalize_result.output = output;
             }
-            ExecutedException::VM(VMError::InvalidNonce) => Some(ExecutionError::InvalidNonce),
-            ExecutedException::VM(VMError::NotEnoughBaseGas) => {
-                Some(ExecutionError::NotEnoughBaseGas)
+            Ok(InterpreterResult::Revert(output, gas_left)) => {
+                if self.payment_required() {
+                    if let Err(e) = liquidtion(
+                        self.state_provider.clone(),
+                        store.clone(),
+                        sender,
+                        gas_price,
+                        gas_limit.as_u64(),
+                        gas_left,
+                        0,
+                    ) {
+                        finalize_result.exception = Some(ExecutedException::VM(e));
+                        return finalize_result;
+                    }
+                }
+                self.state_provider
+                    .borrow_mut()
+                    .kill_garbage(&store.borrow().inused.clone());
+
+                finalize_result.quota_used = gas_limit - U256::from(gas_left);
+                finalize_result.quota_left = U256::from(gas_left);
+                finalize_result.exception = Some(ExecutedException::Reverted);
+                trace!(
+                    "Get data after executed the transaction [Revert]: {:?}",
+                    output
+                );
             }
-            ExecutedException::VM(VMError::NotEnoughBalance) => {
-                Some(ExecutionError::NotEnoughBalance)
+            Ok(InterpreterResult::Create(output, gas_left, logs, addr)) => {
+                if self.payment_required() {
+                    let refund = get_refund(store.clone(), sender, gas_limit.as_u64(), gas_left);
+                    if let Err(e) = liquidtion(
+                        self.state_provider.clone(),
+                        store.clone(),
+                        sender,
+                        gas_price,
+                        gas_limit.as_u64(),
+                        gas_left,
+                        refund,
+                    ) {
+                        finalize_result.exception = Some(ExecutedException::VM(e));
+                        return finalize_result;
+                    }
+                }
+
+                for e in store.borrow_mut().selfdestruct.drain() {
+                    self.state_provider.borrow_mut().kill_contract(&e);
+                }
+                self.state_provider
+                    .borrow_mut()
+                    .kill_garbage(&store.borrow().inused.clone());
+                finalize_result.quota_used = gas_limit - U256::from(gas_left);
+                finalize_result.quota_left = U256::from(gas_left);
+                finalize_result.logs = transform_logs(logs);
+                finalize_result.logs_bloom = logs_to_bloom(&finalize_result.logs);
+                finalize_result.contract_address = Some(addr);
+
+                trace!(
+                "Get data after executed the transaction [Create], contract address: {:?}, contract data : {:?}",
+                finalize_result.contract_address, output
+                );
             }
-            _ => None,
+            Err(e) => {
+                if self.payment_required() {
+                    if let Err(e) = liquidtion(
+                        self.state_provider.clone(),
+                        store.clone(),
+                        sender,
+                        gas_price,
+                        gas_limit.as_u64(),
+                        0,
+                        0,
+                    ) {
+                        finalize_result.exception = Some(ExecutedException::VM(e));
+                        return finalize_result;
+                    }
+                }
+                self.state_provider
+                    .borrow_mut()
+                    .kill_garbage(&store.borrow().inused.clone());
+
+                finalize_result.exception = Some(ExecutedException::VM(e));
+                finalize_result.quota_used = gas_limit;
+                finalize_result.quota_left = U256::from(0);
+            }
         }
+
+        finalize_result
     }
 
     fn payment_required(&self) -> bool {
@@ -304,48 +400,6 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
                 .sub_balance(&sender, U256::from(gas_cost))?;
         }
         Ok(())
-    }
-
-    fn refund(&mut self, address: &Address, value: U256) -> Result<(), ExecutionError> {
-        if self.payment_required() {
-            self.state_provider
-                .borrow_mut()
-                .add_balance(address, value)
-                .map_err(ExecutionError::from)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn handle_tx_fee(
-        &mut self,
-        coin_base: &Address,
-        fee_value: U256,
-    ) -> Result<(), ExecutionError> {
-        if self.payment_required() {
-            self.state_provider
-                .borrow_mut()
-                .add_balance(coin_base, fee_value)
-                .map_err(ExecutionError::from)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn transfer_balance(
-        &mut self,
-        from: &Address,
-        to: &Address,
-        value: U256,
-    ) -> Result<(), ExecutionError> {
-        if self.payment_required() {
-            self.state_provider
-                .borrow_mut()
-                .transfer_balance(from, to, value)
-                .map_err(ExecutionError::from)
-        } else {
-            Ok(())
-        }
     }
 
     fn transact_set_abi(&mut self, data: &[u8]) -> bool {
@@ -495,99 +549,170 @@ impl<'a, B: DB + 'static> CitaExecutive<'a, B> {
             _ => Ok(None),
         }
     }
+}
 
-    pub fn call_evm(&mut self, params: &VmExecParams) -> Result<ExecutedResult, ExecutionError> {
-        let mut evm_transaction = build_evm_transaction(params);
-        trace!("block quota limit is {:?}", self.context.block_quota_limit);
-        let mut evm_config = build_evm_config(self.context.block_quota_limit.as_u64());
-        let evm_context = build_evm_context(&self.context);
-
-        if !self.payment_required() {
-            evm_transaction.value = U256::from(0);
-            evm_config.check_balance = false;
+/// Function create creates a new contract.
+pub fn create<B: DB + 'static>(
+    block_provider: Arc<BlockDataProvider>,
+    state_provider: Arc<RefCell<State<B>>>,
+    store: Arc<RefCell<VMSubState>>,
+    request: &InterpreterParams,
+    create_kind: CreateKind,
+) -> Result<evm::InterpreterResult, VMError> {
+    debug!("create request={:?}", request);
+    let address = match create_kind {
+        CreateKind::FromAddressAndNonce => {
+            // Generate new address created from address, nonce
+            create_address_from_address_and_nonce(&request.sender, &request.nonce)
         }
-
-        trace!("Call evm with params: {:?}", params);
-        let mut result = match cita_vm::exec(
-            self.block_provider.clone(),
-            self.state_provider.clone(),
-            evm_context,
-            evm_config,
-            evm_transaction,
-        ) {
-            Ok(evm_result) => build_result_with_ok(params.gas, evm_result),
-            Err(e) => build_result_with_err(e),
-        };
-        result.is_evm_call = true;
-        Ok(result)
+        CreateKind::FromSaltAndCodeHash => {
+            // Generate new address created from sender salt and code hash
+            create_address_from_salt_and_code_hash(
+                &request.sender,
+                request.extra,
+                request.input.clone(),
+            )
+        }
+    };
+    debug!("create address={:?}", address);
+    // Ensure there's no existing contract already at the designated address
+    if !can_create(state_provider.clone(), &address)? {
+        return Err(VMError::ContractAlreadyExist);
     }
-
-    fn call(&mut self, params: &VmExecParams) -> Result<ExecutedResult, ExecutionError> {
-        // Check and call Native Contract.
-        if let Some(mut native_contract) = self
-            .native_factory
-            .new_contract(params.code_address.unwrap())
-        {
-            self.prepaid(&params.sender, params.gas, params.gas_price, params.value)?;
-
-            // Backup used in case of running out of gas
-            self.state_provider.borrow_mut().checkpoint();
-
-            // At first, transfer value to destination.
-            if self.payment_required()
-                && self
-                    .transfer_balance(&params.sender, &params.to_address.unwrap(), params.value)
-                    .is_err()
-            {
-                // Discard the checkpoint
-                self.state_provider.borrow_mut().revert_checkpoint();
-                return Err(ExecutionError::Internal(
-                    "Transfer balance failed while calling native contract.".to_string(),
-                ));
+    // Make a checkpoint here
+    state_provider.borrow_mut().checkpoint();
+    // Create a new contract
+    let balance = state_provider.borrow_mut().balance(&address)?;
+    state_provider.borrow_mut().new_contract(
+        &address,
+        balance,
+        // The init nonce for a new contract is one, see above documents.
+        U256::zero(),
+        // The init code should be none. Consider a situation: ContractA will create
+        // ContractB with address 0x1ff...fff, but ContractB's init code contains some
+        // op like "get code hash from 0x1ff..fff or get code size form 0x1ff...fff",
+        // The right result should be "summary(none)" and "0".
+        vec![],
+    );
+    let mut reqchan = request.clone();
+    reqchan.address = address;
+    reqchan.receiver = address;
+    reqchan.is_create = false;
+    reqchan.input = vec![];
+    reqchan.contract = evm::Contract {
+        code_address: address,
+        code_data: request.input.clone(),
+    };
+    let r = call(
+        block_provider.clone(),
+        state_provider.clone(),
+        store.clone(),
+        &reqchan,
+    );
+    match r {
+        Ok(evm::InterpreterResult::Normal(output, gas_left, logs)) => {
+            // Ensure code size
+            if output.len() as u64 > MAX_CREATE_CODE_SIZE {
+                state_provider.borrow_mut().revert_checkpoint();
+                return Err(VMError::ExccedMaxCodeSize);
             }
-
-            let store = VmSubState::default();
-            let store = Arc::new(RefCell::new(store));
-            let mut vm_data_provider = DataProvider::new(
-                self.block_provider.clone(),
-                self.state_provider.clone(),
-                store,
-            );
-            let result = match native_contract.exec(params, &self.context, &mut vm_data_provider) {
-                Ok(ret) => {
-                    // Discard the checkpoint
-                    self.state_provider.borrow_mut().discard_checkpoint();
-                    let mut result = build_result_with_ok(params.gas, ret);
-                    result.is_evm_call = false;
-                    result
-                }
-                Err(e) => {
-                    // If error, revert the checkpoint
-                    self.state_provider.borrow_mut().revert_checkpoint();
-
-                    let mut result = ExecutedResult::default();
-                    result.exception = Some(ExecutedException::NativeContract(e));
-                    result.is_evm_call = false;
-                    result
-                }
-            };
-            Ok(result)
-        } else {
-            // Call EVM contract
-            self.call_evm(params)
+            // Pay every byte returnd from CREATE
+            let gas_code_deposit: u64 = 200 * output.len() as u64;
+            if gas_left < gas_code_deposit {
+                state_provider.borrow_mut().revert_checkpoint();
+                return Err(VMError::Evm(evm::Error::OutOfGas));
+            }
+            let gas_left = gas_left - gas_code_deposit;
+            state_provider
+                .borrow_mut()
+                .set_code(&address, output.clone())?;
+            state_provider.borrow_mut().discard_checkpoint();
+            let r = Ok(evm::InterpreterResult::Create(
+                output, gas_left, logs, address,
+            ));
+            debug!("create result={:?}", r);
+            debug!("create gas_left={:?}", gas_left);
+            r
         }
+        Ok(evm::InterpreterResult::Revert(output, gas_left)) => {
+            state_provider.borrow_mut().revert_checkpoint();
+            let r = Ok(evm::InterpreterResult::Revert(output, gas_left));
+            debug!("create gas_left={:?}", gas_left);
+            debug!("create result={:?}", r);
+            r
+        }
+        Err(e) => {
+            debug!("create err={:?}", e);
+            state_provider.borrow_mut().revert_checkpoint();
+            Err(e)
+        }
+        _ => unimplemented!(),
     }
 }
 
-pub fn build_evm_transaction(params: &VmExecParams) -> EVMTransaction {
-    EVMTransaction {
-        from: params.sender,
-        value: params.value,
-        gas_limit: params.gas.as_u64(),
-        gas_price: params.gas_price,
-        input: params.data.clone().unwrap_or_default(),
-        to: params.to_address,
-        nonce: params.nonce,
+/// Function call enters into the specific contract.
+pub fn call<B: DB + 'static>(
+    block_provider: Arc<BlockDataProvider>,
+    state_provider: Arc<RefCell<State<B>>>,
+    store: Arc<RefCell<VMSubState>>,
+    request: &InterpreterParams,
+) -> Result<evm::InterpreterResult, VMError> {
+    // Here not need check twice,becauce prepay is subed ,but need think call_static
+    /*if !request.disable_transfer_value && state_provider.borrow_mut().balance(&request.sender)? < request.value {
+        return Err(err::Error::NotEnoughBalance);
+    }*/
+    // Run
+    state_provider.borrow_mut().checkpoint();
+    let store_son = Arc::new(RefCell::new(store.borrow_mut().clone()));
+    let native_factory = NativeFactory::default();
+    // Check and call Native Contract.
+    if let Some(mut native_contract) = native_factory.new_contract(request.contract.code_address) {
+        let mut vm_data_provider = DataProvider::new(
+            block_provider.clone(),
+            state_provider.clone(),
+            store.clone(),
+        );
+        let context = store.borrow().evm_context.clone();
+        match native_contract.exec(
+            &VmExecParams::from(request.to_owned()),
+            &Context::from(context),
+            &mut vm_data_provider,
+        ) {
+            Ok(ret) => {
+                // Discard the checkpoint
+                state_provider.borrow_mut().discard_checkpoint();
+                Ok(ret)
+            }
+            Err(e) => {
+                // If error, revert the checkpoint
+                state_provider.borrow_mut().revert_checkpoint();
+                Err(e.into())
+            }
+        }
+    } else {
+        let r = call_pure(
+            block_provider.clone(),
+            state_provider.clone(),
+            store_son.clone(),
+            request,
+        );
+        debug!("call result={:?}", r);
+        match r {
+            Ok(evm::InterpreterResult::Normal(output, gas_left, logs)) => {
+                state_provider.borrow_mut().discard_checkpoint();
+                store.borrow_mut().merge(store_son);
+                Ok(evm::InterpreterResult::Normal(output, gas_left, logs))
+            }
+            Ok(evm::InterpreterResult::Revert(output, gas_left)) => {
+                state_provider.borrow_mut().revert_checkpoint();
+                Ok(evm::InterpreterResult::Revert(output, gas_left))
+            }
+            Err(e) => {
+                state_provider.borrow_mut().revert_checkpoint();
+                Err(e)
+            }
+            _ => unimplemented!(),
+        }
     }
 }
 
@@ -601,62 +726,46 @@ pub fn build_evm_context(context: &Context) -> EVMContext {
     }
 }
 
-pub fn build_evm_config(block_gas_limit: u64) -> VMConfig {
-    VMConfig {
-        // block_gas_limit is meaningless in cita_vm, so let it as default_block_quota_limit.
-        block_gas_limit,
-        check_nonce: true,
-        ..Default::default()
-    }
-}
-
-fn build_result_with_ok(init_gas: U256, ret: InterpreterResult) -> ExecutedResult {
-    let mut result = ExecutedResult::default();
-
-    match ret {
-        InterpreterResult::Normal(data, quota_left, logs) => {
-            result.quota_used = init_gas - U256::from(quota_left);
-            result.quota_left = U256::from(quota_left);
-            result.logs = transform_logs(logs);
-            result.logs_bloom = logs_to_bloom(&result.logs);
-
-            trace!(
-                "Get data after executed the transaction [Normal]: {:?}",
-                data
-            );
-            result.output = data;
-        }
-        InterpreterResult::Revert(data, quota_left) => {
-            result.quota_used = init_gas - U256::from(quota_left);
-            result.quota_left = U256::from(quota_left);
-            result.exception = Some(ExecutedException::Reverted);
-
-            trace!(
-                "Get data after executed the transaction [Revert]: {:?}",
-                data
-            );
-        }
-        InterpreterResult::Create(data, quota_left, logs, contract_address) => {
-            result.quota_used = init_gas - U256::from(quota_left);
-            result.quota_left = U256::from(quota_left);
-            result.logs = transform_logs(logs);
-            result.logs_bloom = logs_to_bloom(&result.logs);
-
-            result.contract_address = Some(contract_address);
-            trace!(
-                "Get data after executed the transaction [Create], contract address: {:?}, contract data : {:?}",
-                result.contract_address, data
-            );
-        }
+/// Function get_refund returns the real ammount to refund for a transaction.
+fn get_refund(
+    store: Arc<RefCell<VMSubState>>,
+    origin: Address,
+    gas_limit: u64,
+    gas_left: u64,
+) -> u64 {
+    let refunds_bound = match store.borrow().refund.get(&origin) {
+        Some(&data) => data,
+        None => 0u64,
     };
-    result
+    // Get real ammount to refund
+    std::cmp::min(refunds_bound, (gas_limit - gas_left) >> 1)
 }
 
-fn build_result_with_err(err: VMError) -> ExecutedResult {
-    trace!("EVM run error for the transaction, error info: {:?}", err);
-    let mut result = ExecutedResult::default();
-    result.exception = Some(ExecutedException::VM(err));
-    result
+/// Liquidtion for a transaction.
+fn liquidtion<B: DB + 'static>(
+    state_provider: Arc<RefCell<State<B>>>,
+    store: Arc<RefCell<VMSubState>>,
+    sender: Address,
+    gas_price: U256,
+    gas_limit: u64,
+    gas_left: u64,
+    refund: u64,
+) -> Result<(), VMError> {
+    trace!(
+        "gas_price: {:?}, gas limit:{:?}, gas left: {:?}, refund: {:?}",
+        gas_price,
+        gas_limit,
+        gas_left,
+        refund
+    );
+    state_provider
+        .borrow_mut()
+        .add_balance(&sender, gas_price * (gas_left + refund))?;
+    state_provider.borrow_mut().add_balance(
+        &store.borrow().evm_context.coinbase,
+        gas_price * (gas_limit - gas_left - refund),
+    )?;
+    Ok(())
 }
 
 fn transform_logs(logs: Vec<EVMLog>) -> Vec<Log> {
@@ -688,8 +797,49 @@ fn accrue_log(bloom: &mut Bloom, log: &Log) {
     }
 }
 
+/// Returns new address created from address and nonce.
+pub fn create_address_from_address_and_nonce(address: &Address, nonce: &U256) -> Address {
+    let mut stream = RlpStream::new_list(2);
+    stream.append(address);
+    stream.append(nonce);
+    Address::from(H256::from(summary(stream.as_raw()).as_slice()))
+}
+
+/// Returns new address created from sender salt and code hash.
+/// See: EIP 1014.
+pub fn create_address_from_salt_and_code_hash(
+    address: &Address,
+    salt: H256,
+    code: Vec<u8>,
+) -> Address {
+    let code_hash = &summary(&code[..])[..];
+    let mut buffer = [0u8; 1 + 20 + 32 + 32];
+    buffer[0] = 0xff;
+    buffer[1..=20].copy_from_slice(&address[..]);
+    buffer[(1 + 20)..(1 + 20 + 32)].copy_from_slice(&salt[..]);
+    buffer[(1 + 20 + 32)..].copy_from_slice(code_hash);
+    Address::from(H256::from(summary(&buffer[..]).as_slice()))
+}
+
+/// If a contract creation is attempted, due to either a creation transaction
+/// or the CREATE (or future CREATE2) opcode, and the destination address
+/// already has either nonzero nonce, or nonempty code, then the creation
+/// throws immediately, with exactly the same behavior as would arise if the
+/// first byte in the init code were an invalid opcode. This applies
+/// retroactively starting from genesis.
+///
+/// See: EIP 684
+pub fn can_create<B: DB + 'static>(
+    state_provider: Arc<RefCell<State<B>>>,
+    address: &Address,
+) -> Result<bool, VMError> {
+    let a = state_provider.borrow_mut().nonce(&address)?;
+    let b = state_provider.borrow_mut().code(&address)?;
+    Ok(a.is_zero() && b.is_empty())
+}
+
 #[derive(Clone, Debug)]
-pub struct VmExecParams {
+pub struct ExecutiveParams {
     /// Address of currently executed code.
     pub code_address: Option<Address>,
     /// Sender of current part of the transaction.
@@ -708,10 +858,10 @@ pub struct VmExecParams {
     pub data: Option<Bytes>,
 }
 
-impl Default for VmExecParams {
+impl Default for ExecutiveParams {
     /// Returns default ActionParams initialized with zeros
-    fn default() -> VmExecParams {
-        VmExecParams {
+    fn default() -> ExecutiveParams {
+        ExecutiveParams {
             code_address: None,
             sender: Address::new(),
             to_address: None,
@@ -722,6 +872,109 @@ impl Default for VmExecParams {
             data: None,
         }
     }
+}
+
+pub fn build_vm_exec_params<B: DB + 'static>(
+    params: &ExecutiveParams,
+    state_provider: Arc<RefCell<State<B>>>,
+) -> VmExecParams {
+    let mut vm_exec_params = VmExecParams::default();
+    vm_exec_params.origin = params.sender;
+    vm_exec_params.sender = params.sender;
+    if let Some(data) = params.to_address {
+        vm_exec_params.to_address = data;
+        vm_exec_params.storage_address = data;
+        vm_exec_params.code_address = data;
+        vm_exec_params.code_data = state_provider.borrow_mut().code(&data).unwrap_or_default();
+    }
+
+    vm_exec_params.gas_price = params.gas_price;
+    vm_exec_params.gas = params.gas.as_u64();
+    vm_exec_params.value = params.value;
+    vm_exec_params.data = params.data.clone().unwrap_or_default();
+    vm_exec_params.nonce = params.nonce;
+    vm_exec_params
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct VmExecParams {
+    pub origin: Address,
+    pub storage_address: Address,
+    /// Address of currently executed code.
+    pub code_address: Address,
+    pub code_data: Vec<u8>,
+    /// Sender of current part of the transaction.
+    pub sender: Address,
+    /// Receive address. Usually equal to code_address,
+    pub to_address: Address,
+    /// Gas paid up front for transaction execution
+    pub gas: u64,
+    /// Gas price.
+    pub gas_price: U256,
+    /// Transaction value.
+    pub value: U256,
+    /// nonce
+    pub nonce: U256,
+    /// Input data.
+    pub data: Bytes,
+    pub read_only: bool,
+    pub extra: H256,
+    pub depth: u64,
+    pub disable_transfer_value: bool,
+}
+
+impl From<InterpreterParams> for VmExecParams {
+    fn from(params: InterpreterParams) -> Self {
+        Self {
+            origin: params.origin,
+            storage_address: params.address,
+            code_address: params.contract.code_address,
+            code_data: params.contract.code_data,
+            sender: params.sender,
+            to_address: params.receiver,
+            gas: params.gas_limit,
+            gas_price: params.gas_price,
+            value: params.value,
+            nonce: params.nonce,
+            data: params.input.clone(),
+            read_only: params.read_only,
+            extra: params.extra,
+            depth: params.depth,
+            disable_transfer_value: params.disable_transfer_value,
+        }
+    }
+}
+
+impl Into<InterpreterParams> for VmExecParams {
+    fn into(self) -> InterpreterParams {
+        InterpreterParams {
+            origin: self.origin,
+            address: self.storage_address,
+            contract: Contract {
+                code_address: self.code_address,
+                code_data: self.code_data,
+            },
+            sender: self.sender,
+            receiver: self.to_address,
+            gas_limit: self.gas,
+            gas_price: self.gas_price,
+            value: self.value,
+            nonce: self.nonce,
+            input: self.data.clone(),
+            read_only: self.read_only,
+            extra: self.extra,
+            depth: self.depth,
+            is_create: false,
+            disable_transfer_value: self.disable_transfer_value,
+        }
+    }
+}
+
+/// A selector for func create_address_from_address_and_nonce() and
+/// create_address_from_salt_and_code_hash()
+pub enum CreateKind {
+    FromAddressAndNonce, // use create_address_from_address_and_nonce
+    FromSaltAndCodeHash, // use create_address_from_salt_and_code_hash
 }
 
 #[derive(Default, Debug)]
@@ -747,7 +1000,6 @@ pub struct ExecutedResult {
 #[cfg(test)]
 mod tests {
     use super::{CitaExecutive, Context, ExecutionError, TxGasSchedule};
-    use crate::contracts::native::factory::Factory as NativeFactory;
     use crate::libexecutor::economical_model::EconomicalModel;
     use crate::libexecutor::{block::EVMBlockDataProvider, sys_config::BlockSysConfig};
     use crate::tests::helpers::*;
@@ -800,7 +1052,6 @@ mod tests {
         context.block_quota_limit = U256::from(100_000);
 
         let block_data_provider = EVMBlockDataProvider::new(context.clone());
-        let native_factory = NativeFactory::default();
 
         let state = Arc::new(RefCell::new(state));
 
@@ -808,7 +1059,6 @@ mod tests {
             CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state,
-                &native_factory,
                 &context,
                 EconomicalModel::Charge,
             )
@@ -840,8 +1090,6 @@ mod tests {
         let sender = t.sender();
         let contract = contract_address(t.sender(), &U256::zero());
 
-        let native_factory = NativeFactory::default();
-
         let mut state = get_temp_state();
 
         state
@@ -861,7 +1109,6 @@ mod tests {
             CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Charge,
             )
@@ -901,8 +1148,6 @@ mod tests {
         }
         .fake_sign(keypair.address().clone());
 
-        let native_factory = NativeFactory::default();
-
         let mut state = get_temp_state();
         state.add_balance(t.sender(), U256::from(100_042)).unwrap();
         let mut context = Context::default();
@@ -916,7 +1161,6 @@ mod tests {
             CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Charge,
             )
@@ -945,8 +1189,6 @@ mod tests {
         }
         .fake_sign(keypair.address().clone());
 
-        let native_factory = NativeFactory::default();
-
         let mut state = get_temp_state();
         state.add_balance(t.sender(), U256::from(100_042)).unwrap();
         let mut context = Context::default();
@@ -960,7 +1202,6 @@ mod tests {
             CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Charge,
             )
@@ -989,7 +1230,6 @@ mod tests {
         }
         .fake_sign(keypair.address().clone());
 
-        let native_factory = NativeFactory::default();
         let state = get_temp_state();
         let mut context = Context::default();
         context.block_quota_limit = U256::from(100_000);
@@ -1002,7 +1242,6 @@ mod tests {
             CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Quota,
             )
@@ -1033,7 +1272,6 @@ contract HelloWorld {
         let gas_required = U256::from(schedule.tx_gas + 1000);
 
         let (deploy_code, _runtime_code) = solc("HelloWorld", source);
-        let native_factory = NativeFactory::default();
 
         let keypair = KeyPair::gen_keypair();
         let t = Transaction {
@@ -1062,7 +1300,6 @@ contract HelloWorld {
             CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Quota,
             )
@@ -1093,7 +1330,6 @@ contract AbiTest {
         let gas_required = U256::from(schedule.tx_gas + 100_000);
 
         let (deploy_code, runtime_code) = solc("AbiTest", source);
-        let native_factory = NativeFactory::default();
 
         let keypair = KeyPair::gen_keypair();
         let t = Transaction {
@@ -1126,7 +1362,6 @@ contract AbiTest {
             let _ = CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Quota,
             )
@@ -1161,7 +1396,6 @@ contract AbiTest {
         let data = "552410770000000000000000000000000000000000000000000000000000000012345678"
             .from_hex()
             .unwrap();
-        let native_factory = NativeFactory::default();
         let mut state = get_temp_state();
         state
             .set_code(&contract_addr, runtime_code.clone())
@@ -1192,7 +1426,6 @@ contract AbiTest {
             let _ = CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Quota,
             )
@@ -1236,7 +1469,6 @@ contract AbiTest {
         let data = "552410770000000000000000000000000000000000000000000000000000000012345678"
             .from_hex()
             .unwrap();
-        let native_factory = NativeFactory::default();
 
         let mut state = get_temp_state();
         state
@@ -1268,7 +1500,6 @@ contract AbiTest {
             let res = CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Quota,
             )
@@ -1317,7 +1548,6 @@ contract AbiTest {
         let data = "552410770000000000000000000000000000000000000000000000000000000012345678"
             .from_hex()
             .unwrap();
-        let native_factory = NativeFactory::default();
 
         let mut state = get_temp_state();
         state
@@ -1349,7 +1579,6 @@ contract AbiTest {
             let res = CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Quota,
             )
@@ -1405,8 +1634,6 @@ contract FakePermissionManagement {
         let permission_addr =
             Address::from_str("33f4b16d67b112409ab4ac87274926382daacfac").unwrap();
 
-        let native_factory = NativeFactory::default();
-
         let mut state = get_temp_state();
         let (_, runtime_code) = solc("FakeAuth", fake_auth);
         state.set_code(&auth_addr, runtime_code.clone()).unwrap();
@@ -1446,7 +1673,6 @@ contract FakePermissionManagement {
             let res = CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state.clone(),
-                &native_factory,
                 &context,
                 EconomicalModel::Quota,
             )

--- a/cita-executor/core/src/cita_vm_helper.rs
+++ b/cita-executor/core/src/cita_vm_helper.rs
@@ -1,0 +1,85 @@
+// Copyright Cryptape Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::data_provider::{BlockDataProvider, DataProvider, Store as VMSubState};
+use cita_trie::DB;
+use cita_vm::{
+    evm::{self, InterpreterConf, InterpreterParams},
+    native,
+    state::State,
+    Error as VMError,
+};
+use std::cell::RefCell;
+use std::sync::Arc;
+
+/// Function call_pure enters into the specific contract with no check or checkpoints.
+pub fn call_pure<B: DB + 'static>(
+    block_provider: Arc<BlockDataProvider>,
+    state_provider: Arc<RefCell<State<B>>>,
+    store: Arc<RefCell<VMSubState>>,
+    request: &InterpreterParams,
+) -> Result<evm::InterpreterResult, VMError> {
+    let evm_context = store.borrow().evm_context.clone();
+    let evm_cfg = store.borrow().evm_cfg.clone();
+    let evm_params = request.clone();
+    let evm_data_provider = DataProvider::new(
+        block_provider.clone(),
+        state_provider.clone(),
+        store.clone(),
+    );
+    // Transfer value
+    if !request.disable_transfer_value {
+        state_provider.borrow_mut().transfer_balance(
+            &request.sender,
+            &request.receiver,
+            request.value,
+        )?;
+    }
+
+    // Execute pre-compiled contracts.
+    if native::contains(&request.contract.code_address) {
+        let c = native::get(request.contract.code_address);
+        let gas = c.required_gas(&request.input);
+        if request.gas_limit < gas {
+            return Err(VMError::Evm(evm::Error::OutOfGas));
+        }
+        let r = c.run(&request.input);
+        match r {
+            Ok(ok) => {
+                return Ok(evm::InterpreterResult::Normal(
+                    ok,
+                    request.gas_limit - gas,
+                    vec![],
+                ));
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    // Run
+    let mut evm_it = evm::Interpreter::new(
+        evm_context,
+        evm_cfg,
+        Box::new(evm_data_provider),
+        evm_params,
+    );
+    Ok(evm_it.run()?)
+}
+
+/// Returns the default interpreter configs for Constantinople.
+pub fn get_interpreter_conf() -> InterpreterConf {
+    let mut evm_cfg = InterpreterConf::default();
+    evm_cfg.eip1283 = false;
+    evm_cfg
+}

--- a/cita-executor/core/src/contracts/native/crosschain_verify.rs
+++ b/cita-executor/core/src/contracts/native/crosschain_verify.rs
@@ -53,23 +53,19 @@ impl Contract for CrossChainVerify {
         _context: &Context,
         data_provider: &mut DataProvider,
     ) -> Result<InterpreterResult, NativeError> {
-        if let Some(ref data) = params.data {
-            method_tools::extract_to_u32(&data[..]).and_then(|signature| match signature {
-                sig if sig == *VERIFY_TRANSACTION_FUNC => {
-                    self.verify_transaction(params, data_provider)
-                }
-                sig if sig == *VERIFY_STATE_FUNC => self.verify_state(params, data_provider),
-                sig if sig == *VERIFY_BLOCK_HEADER_FUNC => {
-                    self.verify_block_header(params, data_provider)
-                }
-                sig if sig == *GET_EXPECTED_BLOCK_NUMBER_FUNC => {
-                    self.get_expected_block_number(params, data_provider)
-                }
-                _ => Err(NativeError::Internal("out of gas".to_string())),
-            })
-        } else {
-            Err(NativeError::Internal("out of gas".to_string()))
-        }
+        method_tools::extract_to_u32(&params.data[..]).and_then(|signature| match signature {
+            sig if sig == *VERIFY_TRANSACTION_FUNC => {
+                self.verify_transaction(params, data_provider)
+            }
+            sig if sig == *VERIFY_STATE_FUNC => self.verify_state(params, data_provider),
+            sig if sig == *VERIFY_BLOCK_HEADER_FUNC => {
+                self.verify_block_header(params, data_provider)
+            }
+            sig if sig == *GET_EXPECTED_BLOCK_NUMBER_FUNC => {
+                self.get_expected_block_number(params, data_provider)
+            }
+            _ => Err(NativeError::Internal("out of gas".to_string())),
+        })
     }
     fn create(&self) -> Box<Contract> {
         Box::new(CrossChainVerify::default())
@@ -92,17 +88,13 @@ impl CrossChainVerify {
         params: &VmExecParams,
         data_provider: &mut DataProvider,
     ) -> Result<InterpreterResult, NativeError> {
-        let gas_cost = U256::from(10000);
+        let gas_cost = 10000;
         if params.gas < gas_cost {
             return Err(NativeError::Internal("out of gas".to_string()));
         }
         let gas_left = params.gas - gas_cost;
 
-        if params.data.is_none() {
-            return Err(NativeError::Internal("no data".to_string()));
-        }
-
-        let data = params.data.to_owned().unwrap();
+        let data = params.data.clone();
         trace!("data = {:?}", data);
         let tokens = vec![
             ethabi::ParamType::Address,
@@ -160,7 +152,8 @@ impl CrossChainVerify {
         let relay_info = relay_info.unwrap();
         trace!("relay_info {:?}", proof_data);
 
-        let ret = ChainManagement::ext_chain_id(data_provider, &gas_left, &params.sender);
+        let ret =
+            ChainManagement::ext_chain_id(data_provider, &U256::from(gas_left), &params.sender);
         if ret.is_none() {
             return Err(NativeError::Internal("get chain id failed".to_owned()));
         }
@@ -311,17 +304,13 @@ impl CrossChainVerify {
         params: &VmExecParams,
         data_provider: &mut DataProvider,
     ) -> Result<InterpreterResult, NativeError> {
-        let gas_cost = U256::from(10000);
+        let gas_cost = 10000;
         if params.gas < gas_cost {
             return Err(NativeError::Internal("out of gas".to_string()));
         }
         let mut gas_left = params.gas - gas_cost;
 
-        if params.data.is_none() {
-            return Err(NativeError::Internal("no data".to_string()));
-        }
-
-        let data = params.data.to_owned().unwrap();
+        let data = params.data.clone();
         trace!("data = {:?}", data);
         let tokens = vec![ethabi::ParamType::Uint(32), ethabi::ParamType::Bytes];
 
@@ -346,11 +335,9 @@ impl CrossChainVerify {
         trace!("data = {:?}", block_header_curr_bytes);
         let block_header_curr = Header::from_bytes(&block_header_curr_bytes);
 
-        let block_header_prev_bytes: Vec<u8> = self.block_headers.get_bytes(
-            data_provider,
-            &params.code_address.unwrap(),
-            &chain_id,
-        )?;
+        let block_header_prev_bytes: Vec<u8> =
+            self.block_headers
+                .get_bytes(data_provider, &params.code_address, &chain_id)?;
 
         let verify_result = if block_header_prev_bytes.is_empty() {
             trace!("sync first block header");
@@ -360,7 +347,7 @@ impl CrossChainVerify {
 
             let ret = ChainManagement::ext_authorities(
                 data_provider,
-                &gas_left,
+                &U256::from(gas_left),
                 &params.sender,
                 chain_id,
             );
@@ -368,7 +355,7 @@ impl CrossChainVerify {
                 return Err(NativeError::Internal("get authorities failed".to_owned()));
             }
             let (gas_left_new, authorities) = ret.unwrap();
-            gas_left = gas_left_new;
+            gas_left = gas_left_new.as_u64();
 
             block_header_prev.verify_next(&block_header_curr, &authorities[..])
         };
@@ -377,7 +364,7 @@ impl CrossChainVerify {
             trace!("store the {} block header", block_header_curr.number());
             self.block_headers.set_bytes(
                 data_provider,
-                &params.code_address.unwrap(),
+                &params.code_address,
                 &chain_id,
                 &block_header_curr_bytes,
             )?;
@@ -388,7 +375,7 @@ impl CrossChainVerify {
             );
             self.state_roots.get_array(&chain_id).unwrap().set(
                 data_provider,
-                &params.code_address.unwrap(),
+                &params.code_address,
                 block_header_curr.number(),
                 &U256::from(block_header_curr.state_root()),
             )?;
@@ -401,7 +388,7 @@ impl CrossChainVerify {
         self.output = result;
         Ok(InterpreterResult::Normal(
             self.output.clone(),
-            gas_left.low_u64(),
+            gas_left,
             vec![],
         ))
     }
@@ -411,17 +398,13 @@ impl CrossChainVerify {
         params: &VmExecParams,
         data_provider: &mut DataProvider,
     ) -> Result<InterpreterResult, NativeError> {
-        let gas_cost = U256::from(10000);
+        let gas_cost = 10000;
         if params.gas < gas_cost {
             return Err(NativeError::Internal("out of gas".to_string()));
         }
         let gas_left = params.gas - gas_cost;
 
-        if params.data.is_none() {
-            return Err(NativeError::Internal("no data".to_string()));
-        }
-
-        let data = params.data.to_owned().unwrap();
+        let data = params.data.clone();
         trace!("data = {:?}", data);
         let tokens = vec![ethabi::ParamType::Uint(32)];
 
@@ -439,11 +422,9 @@ impl CrossChainVerify {
         let chain_id = U256::from_big_endian(&result.unwrap());
         trace!("chain_id = {}", chain_id);
 
-        let block_header_bytes: Vec<u8> = self.block_headers.get_bytes(
-            data_provider,
-            &params.code_address.unwrap(),
-            &chain_id,
-        )?;
+        let block_header_bytes: Vec<u8> =
+            self.block_headers
+                .get_bytes(data_provider, &params.code_address, &chain_id)?;
 
         let block_number = if block_header_bytes.is_empty() {
             0
@@ -460,7 +441,7 @@ impl CrossChainVerify {
         self.output = result;
         Ok(InterpreterResult::Normal(
             self.output.clone(),
-            gas_left.low_u64(),
+            gas_left,
             vec![],
         ))
     }

--- a/cita-executor/core/src/data_provider.rs
+++ b/cita-executor/core/src/data_provider.rs
@@ -1,0 +1,310 @@
+// Copyright Cryptape Technologies LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::cita_executive::{call as ext_call, create as ext_create, CreateKind};
+use cita_trie::DB;
+use cita_types::{Address, H256, U256};
+use cita_vm::evm;
+use cita_vm::state::{State, StateObjectInfo};
+use hashbrown::{HashMap, HashSet};
+use hasher::Hasher;
+use std::cell::RefCell;
+use std::sync::Arc;
+
+/// BlockDataProvider provides functions to get block's hash from chain.
+///
+/// Block data(only hash) are required to cita-vm from externalize database.
+pub trait BlockDataProvider: Send + Sync {
+    /// Function get_block_hash returns the block_hash of the specific block.
+    fn get_block_hash(&self, number: &U256) -> H256;
+}
+
+/// BlockDataProviderMock is a mock for BlockDataProvider. We could use it in
+/// tests or demos.
+#[derive(Default)]
+pub struct BlockDataProviderMock {
+    data: HashMap<U256, H256>,
+}
+
+impl BlockDataProviderMock {
+    /// Set blockhash for a specific block.
+    pub fn set(&mut self, number: U256, hash: H256) {
+        self.data.insert(number, hash);
+    }
+}
+
+/// Impl.
+impl BlockDataProvider for BlockDataProviderMock {
+    fn get_block_hash(&self, number: &U256) -> H256 {
+        *self.data.get(number).unwrap_or(&H256::zero())
+    }
+}
+
+/// Store storages shared datas.
+#[derive(Clone, Default, Debug)]
+pub struct Store {
+    pub refund: HashMap<Address, u64>, // For record refunds
+    pub origin: HashMap<Address, HashMap<H256, H256>>, // For record origin value
+    pub selfdestruct: HashSet<Address>, // For self destruct
+    // Field inused used for garbage collection.
+    //
+    // Test:
+    //   ./tests/jsondata/GeneralStateTests/stSStoreTest/sstore_combinations_initial0.json
+    //   ./tests/jsondata/GeneralStateTests/stSStoreTest/sstore_combinations_initial1.json
+    //   ./tests/jsondata/GeneralStateTests/stSStoreTest/sstore_combinations_initial2.json
+    pub inused: HashSet<Address>,
+    pub evm_context: evm::Context,
+    pub evm_cfg: evm::InterpreterConf,
+}
+
+impl Store {
+    /// Merge with sub store.
+    pub fn merge(&mut self, other: Arc<RefCell<Self>>) {
+        self.refund = other.borrow().refund.clone();
+        self.origin = other.borrow().origin.clone();
+        self.selfdestruct = other.borrow().selfdestruct.clone();
+        self.inused = other.borrow().inused.clone();
+    }
+
+    /// When a account has been read or write, record a log
+    /// to prove that it has dose.
+    pub fn used(&mut self, address: Address) {
+        if address == Address::zero() {
+            return;
+        }
+        self.inused.insert(address);
+    }
+}
+
+/// An implemention for evm::DataProvider
+pub struct DataProvider<B> {
+    pub block_provider: Arc<BlockDataProvider>,
+    pub state_provider: Arc<RefCell<State<B>>>,
+    pub store: Arc<RefCell<Store>>,
+}
+
+impl<B: DB> DataProvider<B> {
+    /// Create a new instance. It's obvious.
+    pub fn new(
+        b: Arc<BlockDataProvider>,
+        s: Arc<RefCell<State<B>>>,
+        store: Arc<RefCell<Store>>,
+    ) -> Self {
+        DataProvider {
+            block_provider: b,
+            state_provider: s,
+            store,
+        }
+    }
+}
+
+impl<B: DB + 'static> evm::DataProvider for DataProvider<B> {
+    fn get_balance(&self, address: &Address) -> U256 {
+        self.state_provider
+            .borrow_mut()
+            .balance(address)
+            .unwrap_or_else(|_| U256::zero())
+    }
+
+    fn add_refund(&mut self, address: &Address, n: u64) {
+        self.store
+            .borrow_mut()
+            .refund
+            .entry(*address)
+            .and_modify(|v| *v += n)
+            .or_insert(n);
+    }
+
+    fn sub_refund(&mut self, address: &Address, n: u64) {
+        debug!("ext.sub_refund {:?} {}", address, n);
+        self.store
+            .borrow_mut()
+            .refund
+            .entry(*address)
+            .and_modify(|v| *v -= n)
+            .or_insert(n);
+    }
+
+    fn get_refund(&self, address: &Address) -> u64 {
+        self.store
+            .borrow_mut()
+            .refund
+            .get(address)
+            .map_or(0, |v| *v)
+    }
+
+    fn get_code_size(&self, address: &Address) -> u64 {
+        self.state_provider
+            .borrow_mut()
+            .code_size(address)
+            .unwrap_or(0) as u64
+    }
+
+    fn get_code(&self, address: &Address) -> Vec<u8> {
+        self.state_provider
+            .borrow_mut()
+            .code(address)
+            .unwrap_or_else(|_| vec![])
+    }
+
+    fn get_code_hash(&self, address: &Address) -> H256 {
+        self.state_provider
+            .borrow_mut()
+            .code_hash(address)
+            .unwrap_or_else(|_| H256::zero())
+    }
+
+    fn get_block_hash(&self, number: &U256) -> H256 {
+        self.block_provider.get_block_hash(number)
+    }
+
+    fn get_storage(&self, address: &Address, key: &H256) -> H256 {
+        self.state_provider
+            .borrow_mut()
+            .get_storage(address, key)
+            .unwrap_or_else(|_| H256::zero())
+    }
+
+    fn set_storage(&mut self, address: &Address, key: H256, value: H256) {
+        let a = self.get_storage(address, &key);
+        self.store
+            .borrow_mut()
+            .origin
+            .entry(*address)
+            .or_insert_with(HashMap::new)
+            .entry(key)
+            .or_insert(a);
+        if let Err(e) = self
+            .state_provider
+            .borrow_mut()
+            .set_storage(address, key, value)
+        {
+            panic!("{}", e);
+        }
+    }
+
+    fn get_storage_origin(&self, address: &Address, key: &H256) -> H256 {
+        //self.store.borrow_mut().used(address.clone());
+        match self.store.borrow_mut().origin.get(address) {
+            Some(account) => match account.get(key) {
+                Some(val) => *val,
+                None => self.get_storage(address, key),
+            },
+            None => self.get_storage(address, key),
+        }
+    }
+
+    fn set_storage_origin(&mut self, _address: &Address, _key: H256, _value: H256) {
+        unimplemented!()
+    }
+
+    fn selfdestruct(&mut self, address: &Address, refund_to: &Address) -> bool {
+        if self.store.borrow_mut().selfdestruct.contains(address) {
+            return false;
+        }
+        //self.store.borrow_mut().used(refund_to.clone());
+        self.store.borrow_mut().selfdestruct.insert(address.clone());
+        let b = self.get_balance(address);
+
+        if address != refund_to {
+            self.state_provider
+                .borrow_mut()
+                .transfer_balance(address, refund_to, b)
+                .unwrap();
+        } else {
+            // Must ensure that the balance of address which is suicide is zero.
+            self.state_provider
+                .borrow_mut()
+                .sub_balance(address, b)
+                .unwrap();
+        }
+        true
+    }
+
+    fn sha3(&self, data: &[u8]) -> H256 {
+        From::from(&hasher::HasherKeccak::new().digest(data)[..])
+    }
+
+    fn is_empty(&self, address: &Address) -> bool {
+        self.state_provider
+            .borrow_mut()
+            .is_empty(address)
+            .unwrap_or(false)
+    }
+
+    fn exist(&self, address: &Address) -> bool {
+        self.state_provider
+            .borrow_mut()
+            .exist(address)
+            .unwrap_or(false)
+    }
+
+    fn call(
+        &self,
+        opcode: evm::OpCode,
+        params: evm::InterpreterParams,
+    ) -> (Result<evm::InterpreterResult, evm::Error>) {
+        match opcode {
+            evm::OpCode::CALL
+            | evm::OpCode::CALLCODE
+            | evm::OpCode::DELEGATECALL
+            | evm::OpCode::STATICCALL => {
+                let r = ext_call(
+                    self.block_provider.clone(),
+                    self.state_provider.clone(),
+                    self.store.clone(),
+                    &params,
+                );
+                debug!("ext.call.result = {:?}", r);
+                r.or(Err(evm::Error::CallError))
+            }
+            evm::OpCode::CREATE | evm::OpCode::CREATE2 => {
+                let mut request = params.clone();
+                request.nonce = self
+                    .state_provider
+                    .borrow_mut()
+                    .nonce(&request.sender)
+                    .or(Err(evm::Error::CallError))?;
+                // Must inc nonce for sender
+                // See: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-161.md
+                self.state_provider
+                    .borrow_mut()
+                    .inc_nonce(&request.sender)
+                    .or(Err(evm::Error::CallError))?;
+
+                let r = match opcode {
+                    evm::OpCode::CREATE => ext_create(
+                        self.block_provider.clone(),
+                        self.state_provider.clone(),
+                        self.store.clone(),
+                        &request,
+                        CreateKind::FromAddressAndNonce,
+                    ),
+                    evm::OpCode::CREATE2 => ext_create(
+                        self.block_provider.clone(),
+                        self.state_provider.clone(),
+                        self.store.clone(),
+                        &request,
+                        CreateKind::FromSaltAndCodeHash,
+                    ),
+                    _ => unimplemented!(),
+                }
+                .or(Err(evm::Error::CallError));
+                debug!("ext.create.result = {:?}", r);
+                r
+            }
+            _ => unimplemented!(),
+        }
+    }
+}

--- a/cita-executor/core/src/lib.rs
+++ b/cita-executor/core/src/lib.rs
@@ -37,7 +37,9 @@ pub extern crate common_types as types;
 pub extern crate core;
 
 pub mod cita_executive;
+pub mod cita_vm_helper;
 pub mod contracts;
+pub mod data_provider;
 pub mod libexecutor;
 pub mod storage;
 pub mod tx_gas_schedule;

--- a/cita-executor/core/src/libexecutor/auto_exec.rs
+++ b/cita-executor/core/src/libexecutor/auto_exec.rs
@@ -12,24 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::contracts::tools::method as method_tools;
-// use crate::engines::NullEngine;
-use crate::libexecutor::block::EVMBlockDataProvider;
-use crate::types::reserved_addresses;
-use cita_types::{Address, H160, U256};
-// use evm::{Factory, VMType};
-use std::str::FromStr;
-// use util::BytesRef;
 use crate::cita_executive::{
     build_evm_context, build_vm_exec_params, call as vm_call, ExecutiveParams,
 };
 use crate::cita_vm_helper::get_interpreter_conf;
+use crate::contracts::tools::method as method_tools;
 use crate::data_provider::Store as VMSubState;
+use crate::libexecutor::block::EVMBlockDataProvider;
 use crate::libexecutor::executor::CitaTrieDB;
 use crate::types::context::Context;
+use crate::types::reserved_addresses;
+use cita_types::{Address, H160, U256};
 use cita_vm::evm::InterpreterResult;
 use cita_vm::state::State as CitaState;
 use std::cell::RefCell;
+use std::str::FromStr;
 use std::sync::Arc;
 
 const AUTO_EXEC: &[u8] = &*b"autoExec()";

--- a/cita-executor/core/src/libexecutor/block.rs
+++ b/cita-executor/core/src/libexecutor/block.rs
@@ -18,19 +18,9 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use cita_merklehash;
-use cita_types::{Address, Bloom as LogBloom, H256, U256};
-use cita_vm::{
-    evm::Error as EVMError, state::State as CitaState, state::StateObjectInfo, BlockDataProvider,
-    Error as VMError,
-};
-use hashable::Hashable;
-use libproto::executor::{ExecutedInfo, ReceiptWithOption};
-use rlp::Encodable;
-
 use crate::cita_executive::CitaExecutive;
-use crate::contracts::native::factory::Factory as NativeFactory;
 use crate::core::context::{Context, LastHashes};
+use crate::data_provider::BlockDataProvider;
 use crate::exception::ExecutedException;
 use crate::libexecutor::auto_exec::auto_exec;
 use crate::libexecutor::economical_model::EconomicalModel;
@@ -44,6 +34,14 @@ use crate::types::errors::Error;
 use crate::types::errors::ReceiptError;
 use crate::types::errors::{AuthenticationError, ExecutionError};
 use crate::types::transaction::SignedTransaction;
+use cita_merklehash;
+use cita_types::{Address, Bloom as LogBloom, H256, U256};
+use cita_vm::{
+    evm::Error as EVMError, state::State as CitaState, state::StateObjectInfo, Error as VMError,
+};
+use hashable::Hashable;
+use libproto::executor::{ExecutedInfo, ReceiptWithOption};
+use rlp::Encodable;
 
 lazy_static! {
     /// Block Reward
@@ -159,12 +157,10 @@ impl ExecutedBlock {
             }
         }
         let block_data_provider = EVMBlockDataProvider::new(context.clone());
-        let native_factory = NativeFactory::default();
 
         let tx_quota_used = match CitaExecutive::new(
             Arc::new(block_data_provider),
             self.state.clone(),
-            &native_factory,
             &context,
             conf.economical_model,
         )

--- a/cita-executor/core/src/libexecutor/command.rs
+++ b/cita-executor/core/src/libexecutor/command.rs
@@ -17,7 +17,6 @@ use super::executor::CitaTrieDB;
 use super::executor::{make_consensus_config, Executor};
 use super::sys_config::GlobalSysConfig;
 use crate::cita_executive::{CitaExecutive, ExecutedResult as CitaExecuted};
-use crate::contracts::native::factory::Factory as NativeFactory;
 use crate::contracts::solc::{
     sys_config::ChainId, PermissionManagement, SysConfig, VersionManager,
 };
@@ -290,7 +289,6 @@ impl Commander for Executor {
         conf.exempt_checking();
 
         let block_data_provider = EVMBlockDataProvider::new(context.clone());
-        let native_factory = NativeFactory::default();
 
         let state_root = if let Some(h) = self.block_header(block_tag) {
             (*h.state_root())
@@ -314,7 +312,6 @@ impl Commander for Executor {
         CitaExecutive::new(
             Arc::new(block_data_provider),
             state,
-            &native_factory,
             &context,
             conf.economical_model,
         )

--- a/cita-executor/core/src/tests/amend_data_test.rs
+++ b/cita-executor/core/src/tests/amend_data_test.rs
@@ -16,14 +16,13 @@ use std::cell::RefCell;
 use std::sync::Arc;
 
 use crate::cita_executive::CitaExecutive;
-use crate::contracts::native::factory::Factory as NativeFactory;
 use crate::libexecutor::{economical_model::EconomicalModel, sys_config::BlockSysConfig};
 use crate::tests::helpers::get_temp_state;
 use crate::types::context::Context;
 use crate::types::transaction::Action;
 
+use crate::data_provider::BlockDataProviderMock;
 use cita_types::{Address, H256, U256};
-use cita_vm::BlockDataProviderMock;
 use core::transaction::{SignedTransaction, Transaction};
 use types::Bytes;
 
@@ -50,13 +49,11 @@ fn build_transaction(
 #[test]
 fn test_amend_tool() {
     let state = get_temp_state();
-    let native_factory = NativeFactory::default();
     let context = Context::default();
 
     let mut e = CitaExecutive::new(
         Arc::new(BlockDataProviderMock::default()),
         Arc::new(RefCell::new(state)),
-        &native_factory,
         &context,
         EconomicalModel::default(),
     );

--- a/tests/json-test/src/state_test.rs
+++ b/tests/json-test/src/state_test.rs
@@ -16,7 +16,6 @@ use crate::helper::{secret_2_address, string_2_bytes, string_2_h256, string_2_u2
 use crate::json::state::Test;
 
 use core_executor::cita_executive::CitaExecutive;
-use core_executor::contracts::native::factory::Factory as NativeFactory;
 use core_executor::libexecutor::sys_config::BlockSysConfig;
 use core_executor::libexecutor::{block::EVMBlockDataProvider, economical_model::EconomicalModel};
 use core_executor::types::{context::Context, transaction::Transaction}; //,Action,SignedTransaction};
@@ -85,11 +84,9 @@ pub fn test_json_file(p: &str) {
             evm_context.last_hashes = Arc::new(vec![string_2_h256(str_prev_hash)]);
 
             let block_data_provider = EVMBlockDataProvider::new(evm_context.clone());
-            let native_factory = NativeFactory::default();
             let mut exepinst = CitaExecutive::new(
                 Arc::new(block_data_provider),
                 state_provider.clone(),
-                &native_factory,
                 &evm_context,
                 EconomicalModel::Charge,
             );


### PR DESCRIPTION
## Refact executive
- Rewrite the `data_provider`, see data_provider.rs.
- Call cita-vm using its `interpreter.run` interface, see cita_vm_helper.rs.
- Refactoring `cita_executive` 's `exec` function:
  - Rewrite the `call` function, which will be called in cita-vm context. And tt is the key for Native-Contract and Solidity-Contract calling each other.
  - Handle the refund and transaction fee in only one function : see `finalize`.