### PR TITLE
Fix: sync 2 new block for each 6s

### DIFF
--- a/cita-executor/src/postman.rs
+++ b/cita-executor/src/postman.rs
@@ -310,7 +310,7 @@ impl Postman {
                 for proto_block in sync_res.take_blocks().into_iter() {
                     let open_block = OpenBlock::from(proto_block);
                     if !self.backlogs.insert_synchronized(open_block) {
-                        return false;
+                        continue;
                     }
                 }
                 true

--- a/cita-network/src/synchronizer.rs
+++ b/cita-network/src/synchronizer.rs
@@ -213,7 +213,7 @@ impl Synchronizer {
             self.add_latest_sync_lists(status.get_height(), origin);
 
             if self.remote_sync_time_out.elapsed().as_secs() > SYNC_TIME_OUT
-                && !self.is_synchronizing
+                || !self.is_synchronizing
             {
                 self.start_sync_req(current_height + 1);
             }


### PR DESCRIPTION
Fix: sync 2 new block for each 6s.

Before fixed, it needs 6s to sync 2 new blocks:
```
2019-09-24 - 15:45:26 | cita_network::synchr - 134   | INFO  - current: 1808, sync_end: 1808, global: 1809, sync: true
2019-09-24 - 15:45:26 | cita_network::synchr - 134   | INFO  - current: 1809, sync_end: 1808, global: 1809, sync: true
2019-09-24 - 15:45:32 | cita_network::synchr - 134   | INFO  - current: 1810, sync_end: 1810, global: 1811, sync: true
2019-09-24 - 15:45:32 | cita_network::synchr - 134   | INFO  - current: 1811, sync_end: 1810, global: 1811, sync: true
2019-09-24 - 15:45:38 | cita_network::synchr - 134   | INFO  - current: 1812, sync_end: 1812, global: 1813, sync: true
2019-09-24 - 15:45:38 | cita_network::synchr - 134   | INFO  - current: 1813, sync_end: 1812, global: 1813, sync: true
2019-09-24 - 15:45:44 | cita_network::synchr - 134   | INFO  - current: 1814, sync_end: 1814, global: 1815, sync: true
2019-09-24 - 15:45:44 | cita_network::synchr - 134   | INFO  - current: 1815, sync_end: 1814, global: 1815, sync: true
```

After fixed, it need 3s to sync 1 new blocks:
```
2019-09-24 - 16:08:02 | cita_network::synchr - 134   | INFO  - current: 2148, sync_end: 2147, global: 2148, sync: true
2019-09-24 - 16:08:05 | cita_network::synchr - 134   | INFO  - current: 2149, sync_end: 2148, global: 2149, sync: true
2019-09-24 - 16:08:08 | cita_network::synchr - 134   | INFO  - current: 2150, sync_end: 2149, global: 2150, sync: true
2019-09-24 - 16:08:11 | cita_network::synchr - 134   | INFO  - current: 2151, sync_end: 2150, global: 2151, sync: true
2019-09-24 - 16:08:14 | cita_network::synchr - 134   | INFO  - current: 2152, sync_end: 2151, global: 2152, sync: true
2019-09-24 - 16:08:18 | cita_network::synchr - 134   | INFO  - current: 2153, sync_end: 2152, global: 2153, sync: true
```