### PR TITLE
Fix some sub-commands error

### DIFF
--- a/scripts/cita.sh
+++ b/scripts/cita.sh
@@ -446,6 +446,9 @@ parse_command() {
 
 # Test CITA is running in docker.
 cita_in_docker() {
+    if [ ! -d /proc/1/cgroup ] ; then
+        return 1
+    fi
     if grep docker /proc/1/cgroup -qa; then
         return 0
     else


### PR DESCRIPTION
The following options should be relative to Node-config:

- enable_tls
- enable_version
- stdout

So, They are should be an `option` for both `create` and `append` . 