### PR TITLE
Supports JSON-RPC interface: estimateQuota

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
 [[package]]
 name = "authority_manage"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "blake2b"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -536,7 +536,7 @@ dependencies = [
 [[package]]
 name = "cita-crypto"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-ed25519 0.6.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -547,7 +547,7 @@ dependencies = [
 [[package]]
 name = "cita-crypto-trait"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
 ]
@@ -564,7 +564,7 @@ dependencies = [
 [[package]]
 name = "cita-directories"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "cita-ed25519"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -680,7 +680,7 @@ dependencies = [
 [[package]]
 name = "cita-merklehash"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "hashable 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -739,7 +739,7 @@ dependencies = [
 [[package]]
 name = "cita-secp256k1"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "cita-sm2"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-crypto-trait 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -770,7 +770,7 @@ dependencies = [
 [[package]]
 name = "cita-types"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "ethereum-types 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "plain_hasher 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "engine"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1267,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "error"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 
 [[package]]
 name = "error-chain"
@@ -1604,7 +1604,7 @@ dependencies = [
 [[package]]
 name = "hashable"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "blake2b 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1836,7 +1836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "jsonrpc-proto"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1853,7 +1853,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-types"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-types-internals"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1965,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "libproto"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "panic_hook"
 version = "0.0.1"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "proof"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2602,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "pubsub"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "dotenv 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pubsub_kafka 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -2613,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "pubsub_kafka"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "pubsub_rabbitmq"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "amqp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2634,7 +2634,7 @@ dependencies = [
 [[package]]
 name = "pubsub_zeromq"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-logger 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2955,7 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rlp"
 version = "0.2.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -3202,7 +3202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "snappy"
 version = "0.1.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "tx_pool"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "cita-crypto 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",
@@ -3910,7 +3910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "util"
 version = "0.6.0"
-source = "git+https://github.com/cryptape/cita-common.git?branch=develop#084e4e969672f39a5fb27b64679f56be9ab24a4a"
+source = "git+https://github.com/cryptape/cita-common.git?branch=develop#8ba178dde69ab06ded0dc1b65ea2ab6b2e4b21c1"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cita-types 0.1.0 (git+https://github.com/cryptape/cita-common.git?branch=develop)",

--- a/cita-chain/src/forward.rs
+++ b/cita-chain/src/forward.rs
@@ -230,6 +230,14 @@ impl Forward {
                 return;
             }
 
+            Request::estimate_quota(call) => {
+                trace!("Estimate quota {:?}", call);
+                self.ctx_pub
+                    .send((routing_key!(Chain >> Request).into(), imsg))
+                    .unwrap();
+                return;
+            }
+
             Request::transaction_count(tx_count) => {
                 trace!("transaction count request from jsonrpc {:?}", tx_count);
                 self.ctx_pub

--- a/cita-executor/src/postman.rs
+++ b/cita-executor/src/postman.rs
@@ -489,6 +489,31 @@ impl Postman {
                     });
             }
 
+            Request::estimate_quota(call) => {
+                trace!("Estimate quota with params: {:?}", call);
+                let _ = serde_json::from_str::<BlockNumber>(&call.height)
+                    .map(|block_id| {
+                        let call_request = CallRequest::from(call);
+                        command::estimate_quota(
+                            &self.command_req_sender,
+                            &self.command_resp_receiver,
+                            call_request,
+                            block_id.into(),
+                        )
+                        .map(|ok| {
+                            response.set_call_result(ok);
+                        })
+                        .map_err(|err| {
+                            response.set_code(ErrorCode::query_error());
+                            response.set_error_msg(err);
+                        })
+                    })
+                    .map_err(|err| {
+                        response.set_code(ErrorCode::query_error());
+                        response.set_error_msg(format!("{:?}", err));
+                    });
+            }
+
             Request::transaction_count(tx_count) => {
                 trace!("transaction count request from jsonrpc {:?}", tx_count);
                 let _ = serde_json::from_str::<CountOrCode>(&tx_count)


### PR DESCRIPTION
Supports JSON-RPC interface: estimateQuota.

Sample:
```shell
cita> rpc estimateQuota --to 0xb701924639d802dc8093d1a43dffa9939a4506de --data 0x13fb8817
{
  "id": 1,
  "jsonrpc": "2.0",
  "result": "0x0000000000000000000000000000000000000000000000000000000000007fc1"
}
```