### PR TITLE
Bug fix: executor block in estimate quota larger than BQL

### DIFF
--- a/scripts/config_tool/default_config/jsonrpc.toml
+++ b/scripts/config_tool/default_config/jsonrpc.toml
@@ -8,7 +8,7 @@ flag_prof_duration = 0
 
 [http_config]
 allow_origin = "*"
-timeout = 3
+timeout = 60
 enable = true
 listen_port = "1337"
 listen_ip = "0.0.0.0"


### PR DESCRIPTION
Bug fix: executor block in estimate quota larger than BQL.

- Use the max estimate quota as BQL, but not 10 * BQL. If estimate quota exceed BQL, than return Error.

```json
{
  "error": {
    "code": -32003,
    "message": "Requires quota higher than upper limit: 1073741824"
  },
  "id": 1,
  "jsonrpc": "2.0"
}
```

- Set http_config default time to 60s. Some commands will takes a longer time.  