### PR TITLE
two improvments

### DIFF
--- a/scripts/cita.sh
+++ b/scripts/cita.sh
@@ -468,11 +468,9 @@ main() {
     fi
 
     # Delete the verbose parameters.
-    # If use the command 'cita bebop', it should delete 2 verbose parameters.
+    # Left shift 1 argument to remove "bebop"
     if [[ "$1" == "bebop" ]]; then
-        set -- "${@:2}"
-    else
-        set -- "${@:1}"
+        shift
     fi
 
     local command=$1
@@ -490,6 +488,8 @@ main() {
     fi
 
     NODE_NAME=$2
+    # Remove last / if NODE_NAME have it
+    NODE_NAME=${NODE_NAME%*/}
     NODE_PATH=$(realpath "${NODE_NAME}")
     NODE_LOGS_DIR="${NODE_PATH}/logs"
     NODE_DATA_DIR="${NODE_PATH}/data"

--- a/scripts/create_cita_config.py
+++ b/scripts/create_cita_config.py
@@ -95,8 +95,8 @@ class NetworkAddressList(list):
                 continue
             addr = addr_str.split(':')
             if len(addr) == 2 and addr[0] and addr[1]:
-                host = addr[0]
-                port = int(addr[1])
+                host = addr[0].strip()
+                port = int(addr[1].strip())
                 if port > 65535 or port < 1:
                     raise Exception(
                         'input port {} is not right'.format(addr_str))


### PR DESCRIPTION
最近发现两类用户经常犯的小错误：
1. 创建链的配置文件时，节点网络地址列表中不小心加入空格。创建脚本不会报错，运行的时候network报网络地址无法解析。
2. setup/start节点的时候，比如 bin/cita setup test-chain/0 因为最后一个参数（节点名）本身就是目录，很容易后面多一个 /。 导致节点运行之后报错连接不上amqp。

这两个问题都很小，但是出问题之后定位还是要花一些时间的。
因此在代码中加入容错处理：
1. 创建链配置时，对节点网络地址列表进行strip处理，去除多余的空格。
2. 如果发现节点名是 / 结尾的，则自动将其去除。